### PR TITLE
Can we let users do mint/burn/fund/defund just by sending ETH/USM/FUM?

### DIFF
--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -19,12 +19,20 @@ contract FUM is ERC20Permit, Ownable {
     }
 
     /**
+     * @notice If anyone sends ETH here, assume they intend it as a `fund`.
+     */
+    receive() external payable {
+        usm.fundTo{ value: msg.value }(msg.sender, 0);
+    }
+
+
+    /**
      * @notice If a user sends FUM tokens directly to this contract (or to the USM contract), assume they intend it as a `defund`.
      * @return success Transfer success
      */
     function transfer(address recipient, uint256 amount) public virtual override returns (bool success) {
         if (recipient == address(this) || recipient == address(usm)) {
-            usm.defundTo(_msgSender(), _msgSender(), amount, 0);
+            usm.defundFromFUM(_msgSender(), _msgSender(), amount);
         } else {
             _transfer(_msgSender(), recipient, amount);
         }

--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -19,12 +19,16 @@ contract FUM is ERC20Permit, Ownable {
     }
 
     /**
-     * @notice Regular transfer, disallowing transfers to this contract.
+     * @notice If a user sends FUM tokens directly to this contract (or to the USM contract), assume they intend it as a `defund`.
+     * @return success Transfer success
      */
-    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
-        require(recipient != address(this) && recipient != address(usm), "Don't transfer here");
-        _transfer(_msgSender(), recipient, amount);
-        return true;
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool success) {
+        if (recipient == address(this) || recipient == address(usm)) {
+            usm.defundTo(_msgSender(), _msgSender(), amount, 0);
+        } else {
+            _transfer(_msgSender(), recipient, amount);
+        }
+        success = true;
     }
 
     /**

--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -10,4 +10,5 @@ interface IUSM {
     function fundTo(address to, uint minFumOut) external payable returns (uint);
     function defund(uint fumToBurn) external returns (uint);
     function defundTo(address from, address payable to, uint fumToBurn, uint minEthOut) external returns (uint);
+    function defundFromFUM(address from, address payable to, uint fumToBurn) external returns (uint);
 }

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -22,9 +22,14 @@ contract Proxy {
     }
 
     /**
-     * @dev The WETH9 contract will send ether to Proxy on `weth.withdraw` using this function.
+     * @notice The WETH9 contract will send ETH to this contract on `weth.withdraw` using this function.  If anyone other than the
+     * WETH contract sends ETH here, assume they intend it as a `mint`.
      */
-     receive() external payable { }
+    receive() external payable {
+        if (msg.sender != address(weth)) {
+            usm.mintTo(msg.sender, 0);
+        }
+    }
 
     /**
      * @notice Accepts WETH, converts it to ETH, and passes it to `usm.mintTo`.

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -22,9 +22,12 @@ contract Proxy {
     }
 
     /**
-     * @notice The WETH9 contract will send ETH to this contract on `weth.withdraw` using this function.
+     * @notice The USM contract's `burn`/`defund` functions will send ETH back to this contract, and the WETH9 contract will send
+     * ETH here on `weth.withdraw` using this function.  If anyone else tries to send ETH here, reject it.
      */
-    receive() external payable {}
+    receive() external payable {
+        require(msg.sender == address(usm) || msg.sender == address(weth), "Don't transfer here");
+    }
 
     /**
      * @notice Accepts WETH, converts it to ETH, and passes it to `usm.mintTo`.

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -22,14 +22,9 @@ contract Proxy {
     }
 
     /**
-     * @notice The WETH9 contract will send ETH to this contract on `weth.withdraw` using this function.  If anyone other than the
-     * WETH contract sends ETH here, assume they intend it as a `mint`.
+     * @notice The WETH9 contract will send ETH to this contract on `weth.withdraw` using this function.
      */
-    receive() external payable {
-        if (msg.sender != address(weth)) {
-            usm.mintTo(msg.sender, 0);
-        }
-    }
+    receive() external payable {}
 
     /**
      * @notice Accepts WETH, converts it to ETH, and passes it to `usm.mintTo`.

--- a/contracts/USMTemplate.sol
+++ b/contracts/USMTemplate.sol
@@ -142,6 +142,21 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
     }
 
     /**
+     * @notice Defunds the pool by redeeming FUM from an arbitrary address in exchange for equivalent ETH from the pool.
+     * Called only by the FUM contract, when FUM is sent to it.
+     * @param from address to deduct the FUM from.
+     * @param to address to send the ETH to.
+     * @param fumToBurn Amount of FUM to burn.
+     */
+    function defundFromFUM(address from, address payable to, uint fumToBurn)
+        external override
+        returns (uint ethOut)
+    {
+        require(msg.sender == address(fum), "Restricted to FUM");
+        ethOut = _defundTo(from, to, fumToBurn, 0);
+    }
+
+    /**
      * @notice If anyone sends ETH here, assume they intend it as a `mint`.
      */
     receive() external payable {

--- a/contracts/USMTemplate.sol
+++ b/contracts/USMTemplate.sol
@@ -142,12 +142,22 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
     }
 
     /**
-     * @notice Regular transfer, disallowing transfers to this contract.
-     * @return success Transfer successfumPrice
+     * @notice If anyone sends ETH here, assume they intend it as a `mint`.
+     */
+    receive() external payable {
+        _mintTo(msg.sender, 0);
+    }
+
+    /**
+     * @notice If a user sends USM tokens directly to this contract (or to the FUM contract), assume they intend it as a `burn`.
+     * @return success Transfer success
      */
     function transfer(address recipient, uint256 amount) public virtual override returns (bool success) {
-        require(recipient != address(this) && recipient != address(fum), "Don't transfer here");
-        _transfer(_msgSender(), recipient, amount);
+        if (recipient == address(this) || recipient == address(fum)) {
+            _burnTo(msg.sender, msg.sender, amount, 0);
+        } else {
+            _transfer(_msgSender(), recipient, amount);
+        }
         success = true;
     }
 


### PR DESCRIPTION
This is just draft code to start from...  You may know cleaner ways.  The "send ETH to USM contract to do a `mint()`" part works here at least some of the time but "send USM to USM contract (or FUM contract) to do a `burn()`" didn't work for me just now.