### PR TITLE
Override _transfer() rather than transfer()?

### DIFF
--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -30,7 +30,7 @@ contract FUM is ERC20Permit, Ownable {
 
     /**
      * @notice If a user sends FUM tokens directly to this contract (or to the USM contract), assume they intend it as a `defund`.
-     * If using `transfer`/`transferFrom` as `defund, and if decimals 8 to 11 (included) of the amount transferred received
+     * If using `transfer`/`transferFrom` as `defund`, and if decimals 8 to 11 (included) of the amount transferred received
      * are `0000` then the next 7 will be parsed as the maximum FUM price accepted, with 5 digits before and 2 digits after the comma.
      */
     function _transfer(address sender, address recipient, uint256 amount) internal override {

--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -30,17 +30,15 @@ contract FUM is ERC20Permit, Ownable {
 
     /**
      * @notice If a user sends FUM tokens directly to this contract (or to the USM contract), assume they intend it as a `defund`.
-     * If using `transfer` as `defund, and if decimals 8 to 11 (included) of the amount transferred received
+     * If using `transfer`/`transferFrom` as `defund, and if decimals 8 to 11 (included) of the amount transferred received
      * are `0000` then the next 7 will be parsed as the maximum FUM price accepted, with 5 digits before and 2 digits after the comma.
-     * @return success Transfer success
      */
-    function transfer(address recipient, uint256 amount) public virtual override returns (bool success) {
+    function _transfer(address sender, address recipient, uint256 amount) internal override {
         if (recipient == address(this) || recipient == address(usm) || recipient == address(0)) {
-            usm.defundFromFUM(_msgSender(), _msgSender(), amount, MinOut.parseMinEthOut(amount));
+            usm.defundFromFUM(sender, payable(sender), amount, MinOut.parseMinEthOut(amount));
         } else {
-            _transfer(_msgSender(), recipient, amount);
+            super._transfer(sender, recipient, amount);
         }
-        success = true;
     }
 
     /**

--- a/contracts/USMTemplate.sol
+++ b/contracts/USMTemplate.sol
@@ -133,17 +133,15 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
 
     /**
      * @notice If a user sends USM tokens directly to this contract (or to the FUM contract), assume they intend it as a `burn`.
-     * If using `transfer` as `burn`, and if decimals 8 to 11 (included) of the amount transferred received
+     * If using `transfer`/`transferFrom` as `burn`, and if decimals 8 to 11 (included) of the amount transferred received
      * are `0000` then the next 7 will be parsed as the maximum USM price accepted, with 5 digits before and 2 digits after the comma.
-     * @return success Transfer success
      */
-    function transfer(address recipient, uint256 amount) public virtual override returns (bool success) {
+    function _transfer(address sender, address recipient, uint256 amount) internal override {
         if (recipient == address(this) || recipient == address(fum) || recipient == address(0)) {
-            _burnUsm(msg.sender, msg.sender, amount, MinOut.parseMinEthOut(amount));
+            _burnUsm(sender, payable(sender), amount, MinOut.parseMinEthOut(amount));
         } else {
-            _transfer(_msgSender(), recipient, amount);
+            super._transfer(sender, recipient, amount);
         }
-        success = true;
     }
 
     /** INTERNAL TRANSACTIONAL FUNCTIONS */


### PR DESCRIPTION
Reading the [comments](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L197) for OpenZeppelin's `_transfer()` fn ("This internal function is equivalent to `transfer`, and can be used to eg implement automatic token fees, slashing mechanisms, etc"), and the fact that they chose to make it `internal virtual` rather than say `private`, I think this is what they intended overriders like us to do.  Give it a think...  Tests pass fine.