### PR TITLE
First stab at implementing a limit order book for FUM buy orders.

### DIFF
--- a/contracts/FUMLimitOrderBook.sol
+++ b/contracts/FUMLimitOrderBook.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.6;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "./IUSM.sol";
+import "./WadMath.sol";
+
+/**
+ * @title FUMLimitOrderBook
+ * @author Jacob Eliosoff
+ *
+ * @notice Stores FUM buy limit orders sent by users in a heap, plus stores the ETH they sent, and uses it to buy FUM on request,
+ * if the limit price is met.
+ */
+contract FUMLimitOrderBook {
+    using Address for address payable;
+    using SafeMath for uint;
+    using WadMath for uint;
+
+    struct Bid {
+        address sender;
+        uint ethQty;
+        uint maxFumPriceInEth;
+        uint heapIndex;
+    }
+
+    IUSM public immutable usm;
+    mapping(uint => Bid) public bids;       // Maps orderNumber (starts at 1) -> Bid struct
+    uint public numBids;
+    mapping(uint => uint) public bidHeap;     // Maps heap index (starts at 1 - not 0, careful!) -> orderNumber
+    uint public bidHeapSize;
+
+    /* ____________________ Constructor ____________________ */
+
+    constructor(IUSM usm_) public {
+        usm = usm_;
+    }
+
+    /* ____________________ External stateful functions ____________________ */
+
+    function submitBid(uint maxFumPriceInEth) external payable returns (uint orderNumber) {
+        uint heapIndex = ++bidHeapSize;
+        orderNumber = ++numBids;
+        bidHeap[heapIndex] = orderNumber;
+        bids[orderNumber] = Bid(msg.sender, msg.value, maxFumPriceInEth, heapIndex);
+        upheapIfNeeded(heapIndex);
+    }
+
+    function cancelBid(uint orderNumber) external {
+        Bid memory bid = bids[orderNumber];
+        require(bid.sender == msg.sender, "Only creator can cancel");
+        extractBid(bid.heapIndex);
+        msg.sender.sendValue(bid.ethQty);
+    }
+
+    /**
+     * @notice Executes the given bid, if possible given its limit price and the current latestPrice(), *plus all other bids
+     * ahead of it in the queue* (ie, bids with higher maxFumPriceInEth, or the same maxFumPriceInEth and lower orderNumbers).
+     * Fails without effect if any bid fails: so either executes some number of bids including the requested one, or none.
+     */
+    function executeBid(uint orderNumberToExecute) external {
+        require(bids[orderNumberToExecute].sender != address(0), "Bid doesn't exist");
+        uint topOrderNumber;
+        Bid memory topBid;
+        do {
+            (topOrderNumber, topBid) = extractBid(1);    // Again careful - our heap starts at 1, not 0
+            uint minFumOut = topBid.ethQty.wadDivUp(topBid.maxFumPriceInEth);
+            usm.fund{ value: topBid.ethQty }(topBid.sender, minFumOut);
+        } while (topOrderNumber != orderNumberToExecute);
+    }
+
+    /* ____________________ Internal stateful functions ____________________ */
+
+    /**
+     * @dev These algos are mostly just adapted from good old Wikipedia.  https://en.wikipedia.org/wiki/Binary_heap
+     */
+    function extractBid(uint heapIndex) internal returns (uint orderNumber, Bid memory bid) {
+        swapHeapElements(heapIndex, bidHeapSize);
+
+        orderNumber = bidHeap[bidHeapSize];
+        delete bidHeap[bidHeapSize];
+        --bidHeapSize;
+        bid = bids[orderNumber];
+        delete bids[orderNumber];
+
+        downheapIfNeeded(heapIndex);
+
+        return (orderNumber, bid);
+    }
+
+    /**
+     * @notice Repeatedly swap with its parent - the bid at index heapIndex/2 (rounded down) - if both a) the parent exists
+     * (we're not already at index 1), and b) we belong ahead of the parent in the queue.
+     */
+    function upheapIfNeeded(uint heapIndex) internal {
+        uint parentHeapIndex = heapIndex / 2;
+        if ((parentHeapIndex > 0) && belongsBefore(heapIndex, parentHeapIndex)) {
+            swapHeapElements(heapIndex, parentHeapIndex);
+            upheapIfNeeded(parentHeapIndex);
+        }
+    }
+
+    /**
+     * @notice Repeatedly swap with the child (at indices 2*heapIndex and 2*heapIndex+1) that belongs earliest in the queue, if at
+     * least one child a) exists and b) belongs earlier in the queue than this element.  Eg, if heapIndex = 13, we need to compare
+     * and possibly swap with the elements at indices 26 and 27.  Then if, say, element 27 belonged ahead so we swapped 13 with
+     * it, we need to consider swapping element 27 with elements 54 or 55, and so on.
+     */
+    function downheapIfNeeded(uint heapIndex) internal {
+        uint child1HeapIndex = 2 * heapIndex;
+        uint child2HeapIndex = 2 * heapIndex + 1;
+        if (child1HeapIndex <= bidHeapSize) {
+            if (belongsBefore(child1HeapIndex, heapIndex) &&
+                (child2HeapIndex > bidHeapSize || belongsBefore(child1HeapIndex, child2HeapIndex)))
+            {
+                swapHeapElements(heapIndex, child1HeapIndex);
+                downheapIfNeeded(child1HeapIndex);
+            } else if (child2HeapIndex <= bidHeapSize && belongsBefore(child2HeapIndex, heapIndex)) {
+                swapHeapElements(heapIndex, child2HeapIndex);
+                downheapIfNeeded(child2HeapIndex);
+            }
+        }   // Neither child exists - no downheaping to do.
+    }
+
+    function swapHeapElements(uint heapIndex1, uint heapIndex2) internal {
+        // First, swap the orderNumbers pointed to by the two bidHeap indices:
+        (bidHeap[heapIndex1], bidHeap[heapIndex2]) = (bidHeap[heapIndex2], bidHeap[heapIndex1]);
+        // Then, update each bid's internal heapIndex member:
+        bids[bidHeap[heapIndex1]].heapIndex = heapIndex1;
+        bids[bidHeap[heapIndex2]].heapIndex = heapIndex2;
+    }
+
+    /* ____________________ Internal view functions ____________________ */
+
+    /**
+     * @return before whether bid1 belongs before bid2 in the queue.
+     */
+    function belongsBefore(uint heapIndex1, uint heapIndex2) internal view returns (bool before) {
+        uint orderNumber1 = bidHeap[heapIndex1];
+        uint orderNumber2 = bidHeap[heapIndex2];
+        uint bid1Price = bids[orderNumber1].maxFumPriceInEth;
+        uint bid2Price = bids[orderNumber2].maxFumPriceInEth;
+        before = (bid1Price > bid2Price) || (bid1Price == bid2Price && orderNumber1 < orderNumber2);
+    }
+
+    /* ____________________ External view functions, for testing ____________________ */
+
+    function getOrderNumber(uint heapIndex) external view returns (uint num) {
+        num = bidHeap[heapIndex];
+    }
+
+    function getBidDetails(uint orderNumber) external view returns (address sender, uint qty, uint price, uint heapIndex) {
+        sender = bids[orderNumber].sender;
+        qty = bids[orderNumber].ethQty;
+        price = bids[orderNumber].maxFumPriceInEth;
+        heapIndex = bids[orderNumber].heapIndex;
+    }
+}

--- a/test/06_Limit_Orders.test.js
+++ b/test/06_Limit_Orders.test.js
@@ -1,0 +1,182 @@
+const { BN, expectRevert } = require('@openzeppelin/test-helpers')
+const { web3 } = require('@openzeppelin/test-helpers/src/setup')
+const timeMachine = require('ganache-time-traveler')
+
+const USM = artifacts.require('MockTestOracleUSM')
+const FUM = artifacts.require('FUM')
+const FUMLimitOrderBook = artifacts.require('FUMLimitOrderBook')
+
+require('chai').use(require('chai-as-promised')).should()
+
+contract('USM', (accounts) => {
+  const [deployer, user1, user2] = accounts
+  const [ONE, TWO, FOUR, WAD] =
+        [1, 2, 4, '1000000000000000000'].map(function (n) { return new BN(n) })
+  const MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+  const sides = { BUY: 0, SELL: 1 }
+  const rounds = { DOWN: 0, UP: 1 }
+  const oneEth = WAD
+
+  const price = new BN(250)
+  const priceWAD = price.mul(WAD)
+  let oneDollarInEth
+
+  function wadDiv(x, y, upOrDown) {
+    return ((x.mul(WAD)).add(y.sub(ONE))).div(y)
+  }
+
+  function shouldEqual(x, y) {
+    x.toString().should.equal(y.toString())
+  }
+
+  function shouldEqualApprox(x, y) {
+    // Check that abs(x - y) < 0.0000001(x + y):
+    const diff = (x.gt(y) ? x.sub(y) : y.sub(x))
+    diff.should.be.bignumber.lt(x.add(y).div(new BN(1000000)))
+  }
+
+  describe("mints and burns a static amount", () => {
+    let usm, fum, orderBook, ethPerFund, ethPerMint, bidSize, bidPrices, snapshot, snapshotId
+
+    beforeEach(async () => {
+      // USM
+      usm = await USM.new(priceWAD, { from: deployer })
+      fum = await FUM.at(await usm.fum())
+      orderBook = await FUMLimitOrderBook.new(usm.address)
+
+      await usm.approve(user1, MAX, { from: user1 })
+      await fum.approve(user1, MAX, { from: user1 })
+      await usm.addDelegate(fum.address, { from: user1 })
+      await usm.addDelegate(usm.address, { from: user1 })
+
+      oneDollarInEth = wadDiv(WAD, priceWAD, rounds.UP)
+
+      ethPerFund = oneEth.mul(TWO)                  // Can be any (?) number
+      ethPerMint = oneEth.mul(FOUR)                 // Can be any (?) number
+      bidSize = oneEth.div(new BN(10))
+      bidPrices = [7, 100, 3, 10, 8, 9, 4, 15, 2, 3, 100, 200, 900, 70, 5]
+
+      snapshot = await timeMachine.takeSnapshot()
+      snapshotId = snapshot['result']
+    })
+
+    afterEach(async () => {
+      await timeMachine.revertToSnapshot(snapshotId)
+    })
+
+    describe("deployment", () => {
+      it("starts with correct FUM price", async () => {
+        const fumBuyPrice = await usm.fumPrice(sides.BUY)
+        // The FUM price should start off equal to $1, in ETH terms = 1 / price:
+        shouldEqualApprox(fumBuyPrice, oneDollarInEth)
+
+        const fumSellPrice = await usm.fumPrice(sides.SELL)
+        shouldEqualApprox(fumSellPrice, oneDollarInEth)
+      })
+    })
+
+    describe("with existing FUM and USM supply", () => {
+      beforeEach(async () => {
+        await usm.fund(user2, 0, { from: user1, value: ethPerFund })
+        await usm.mint(user1, 0, { from: user2, value: ethPerMint })
+      })
+
+      it("allows limit orders", async () => {
+        for (let j = -1; j < bidPrices.length; ++j) {
+          if (j >= 0) { // So we print the heap both at the start and at the end of the operations loop
+            console.log("Submitting " + bidPrices[j] + "...")
+            await orderBook.submitBid(WAD.mul(new BN(bidPrices[j])).div(new BN(1000)), { from: user1, value: bidSize })
+            console.log("Submitted.")
+          }
+
+          // I wish I knew how to move shared web3 test code like this heap logging into a shared function, but I don't
+          const ethBal = await web3.eth.getBalance(orderBook.address)
+          const fumBal = await fum.totalSupply()
+          console.log(ethBal + " ETH, " + fumBal + " FUM.  Heap:")
+          const heapSize = await orderBook.bidHeapSize()
+          for (let i = 1; i <= heapSize; ++i) {
+            const orderNum = await orderBook.getOrderNumber(new BN(i))
+            if (orderNum != 0) {
+              const {sender, qty, price, heapIndex} = await orderBook.getBidDetails(orderNum)
+              shouldEqual(heapIndex, i)
+              console.log("    " + i + ": bid #" + orderNum + ":\t" + qty + " ETH @ " + price + " ETH per FUM")
+            }
+          }
+        }
+      })
+
+      describe("with existing limit orders", () => {
+        beforeEach(async () => {
+          for (let j = 0; j < bidPrices.length; ++j) {
+            await orderBook.submitBid(WAD.mul(new BN(bidPrices[j])).div(new BN(1000)), { from: user1, value: bidSize })
+          }
+        })
+
+        it("allows canceling orders", async () => {
+          let orderNums = [3, 13, 12, 5, 8, 4, 10, 2, 1, 9, 11, 7]
+          for (let j = -1; j < orderNums.length; ++j) {
+            if (j >= 0) { // So we print the heap both at the start and at the end of the operations loop
+              console.log("Canceling " + orderNums[j] + "...")
+              await orderBook.cancelBid(new BN(orderNums[j]), { from: user1 })
+              console.log("Canceled.")
+            }
+
+            const ethBal = await web3.eth.getBalance(orderBook.address)
+            const fumBal = await fum.totalSupply()
+            console.log(ethBal + " ETH, " + fumBal + " FUM.  Heap:")
+            const heapSize = await orderBook.bidHeapSize()
+            for (let i = 1; i <= heapSize; ++i) {
+              const orderNum = await orderBook.getOrderNumber(new BN(i))
+              if (orderNum != 0) {
+                const {sender, qty, price, heapIndex} = await orderBook.getBidDetails(orderNum)
+                shouldEqual(heapIndex, i)
+                console.log("    " + i + ": bid #" + orderNum + ":\t" + qty + " ETH @ " + price + " ETH per FUM")
+              }
+            }
+          }
+        })
+
+        it("doesn't allow canceling someone else's order", async () => {
+          orderBook.cancelBid(new BN(11), { from: user1 })
+          await expectRevert(orderBook.cancelBid(new BN(12), { from: user2 }), "Only creator can cancel")
+        })
+
+        it("allows executing orders", async () => {
+          orderNums = [13, 11, 14, 1]
+          for (let j = -1; j < orderNums.length; ++j) {
+            if (j >= 0) { // So we print the heap both at the start and at the end of the operations loop
+              console.log("Executing " + orderNums[j] + "...")
+              await orderBook.executeBid(new BN(orderNums[j]), { from: user1 })
+              console.log("Executed.")
+            }
+
+            const ethBal = await web3.eth.getBalance(orderBook.address)
+            const fumBal = await fum.totalSupply()
+            console.log(ethBal + " ETH, " + fumBal + " FUM.  Heap:")
+            const heapSize = await orderBook.bidHeapSize()
+            for (let i = 1; i <= heapSize; ++i) {
+              const orderNum = await orderBook.getOrderNumber(new BN(i))
+              if (orderNum != 0) {
+                const {sender, qty, price, heapIndex} = await orderBook.getBidDetails(orderNum)
+                shouldEqual(heapIndex, i)
+                console.log("    " + i + ": bid #" + orderNum + ":\t" + qty + " ETH @ " + price + " ETH per FUM")
+              }
+            }
+          }
+        })
+
+        it("doesn't allow executing nonexistent orders", async () => {
+          await expectRevert(orderBook.executeBid(new BN(123), { from: user1 }), "Bid doesn't exist")
+        })
+
+        it("fails to execute order with too-low maxFumPriceInEth", async () => {
+          orderNums = [13, 11, 14, 1]
+          for (let j = 0; j < orderNums.length; ++j) {
+            await orderBook.executeBid(new BN(orderNums[j]), { from: user1 })
+          }
+          await expectRevert(orderBook.executeBid(new BN(3), { from: user1 }), "Limit not reached")
+        })
+      })
+    })
+  })
+})

--- a/test/06_Limit_Orders.test.js
+++ b/test/06_Limit_Orders.test.js
@@ -8,7 +8,7 @@ const FUMLimitOrderBook = artifacts.require('FUMLimitOrderBook')
 
 require('chai').use(require('chai-as-promised')).should()
 
-contract('USM', (accounts) => {
+contract('USM - Limit Order Book', (accounts) => {
   const [deployer, user1, user2] = accounts
   const [ONE, TWO, FOUR, WAD] =
         [1, 2, 4, '1000000000000000000'].map(function (n) { return new BN(n) })

--- a/test/06_Limit_Orders.test.js
+++ b/test/06_Limit_Orders.test.js
@@ -44,11 +44,6 @@ contract('USM', (accounts) => {
       fum = await FUM.at(await usm.fum())
       orderBook = await FUMLimitOrderBook.new(usm.address)
 
-      await usm.approve(user1, MAX, { from: user1 })
-      await fum.approve(user1, MAX, { from: user1 })
-      await usm.addDelegate(fum.address, { from: user1 })
-      await usm.addDelegate(usm.address, { from: user1 })
-
       oneDollarInEth = wadDiv(WAD, priceWAD, rounds.UP)
 
       ethPerFund = oneEth.mul(TWO)                  // Can be any (?) number


### PR DESCRIPTION
Experimental but pretty simple...  The idea is that you send in some ETH with your max price via `submitBid()`, can cancel if you like via `cancelBid(orderNumber)`, and then you (or anyone!) can request execution of the order in the future via `executeOrder(orderNumber)` if the current FUM price (based on `latestPrice()` etc) meets your max bid price.  But someone who requests execution of their order _also_ executes all bids ahead of them in the queue (ie, with higher max prices).

It's a bit weird because the bids aren't _automatically_ executed, and you'd think anyone who chooses to execute their bid waiting in the order book, could just submit a market `fund()` instead...  It's not like this code gives limit orders any price advantage.  But, an outsider might choose to pay gas to execute other people's resting orders: eg, someone wanting to do a `defund`/`burn` but the system is currently underwater, or just a "sweep the order book" bot we run ourselves.