### PR TITLE
TWAP, both for one Uniswap pair and for median-of-three-pairs

### DIFF
--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -10,14 +10,11 @@ contract USM is USMTemplate, MedianOracle {
     constructor(
         AggregatorV3Interface chainlinkAggregator,
         UniswapAnchoredView compoundView,
-        IUniswapV2Pair[NUM_UNISWAP_PAIRS] memory uniswapPairs,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens0Decimals,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens1Decimals,
-        bool[NUM_UNISWAP_PAIRS] memory uniswapTokensInReverseOrder
+        IUniswapV2Pair uniswapPair, uint uniswapToken0Decimals, uint uniswapToken1Decimals, bool uniswapTokensInReverseOrder
     ) public
         USMTemplate()
         MedianOracle(chainlinkAggregator, compoundView,
-                     uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals, uniswapTokensInReverseOrder) {}
+                     uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
 
     function cacheLatestPrice() public virtual override(Oracle, MedianOracle) returns (uint price) {
         price = MedianOracle.cacheLatestPrice();

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.6.6;
 import "./USMTemplate.sol";
 import "./oracles/MedianOracle.sol";
 
-
 contract USM is USMTemplate, MedianOracle {
     uint private constant NUM_UNISWAP_PAIRS = 3;
 
@@ -19,4 +18,8 @@ contract USM is USMTemplate, MedianOracle {
         USMTemplate()
         MedianOracle(chainlinkAggregator, compoundView,
                      uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals, uniswapTokensInReverseOrder) {}
+
+    function cacheLatestPrice() public virtual override(Oracle, MedianOracle) returns (uint price) {
+        price = MedianOracle.cacheLatestPrice();
+    }
 }

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -17,6 +17,6 @@ contract USM is USMTemplate, MedianOracle {
                      uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
 
     function cacheLatestPrice() public virtual override(Oracle, MedianOracle) returns (uint price) {
-        price = MedianOracle.cacheLatestPrice();
+        price = super.cacheLatestPrice();
     }
 }

--- a/contracts/USMTemplate.sol
+++ b/contracts/USMTemplate.sol
@@ -154,7 +154,7 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
         require(ethInPool > 0, "Fund before minting");
 
         // 2. Calculate usmOut:
-        uint ethUsmPrice = latestPrice();
+        uint ethUsmPrice = cacheLatestPrice();
         uint usmTotalSupply = totalSupply();
         uint oldDebtRatio = debtRatio(ethUsmPrice, ethInPool, usmTotalSupply);
         usmOut = usmFromMint(ethUsmPrice, msg.value, ethInPool, usmTotalSupply);
@@ -169,7 +169,7 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
     function _burnUsm(address from, address payable to, uint usmToBurn, uint minEthOut) internal returns (uint ethOut)
     {
         // 1. Calculate ethOut:
-        uint ethUsmPrice = latestPrice();
+        uint ethUsmPrice = cacheLatestPrice();
         uint ethInPool = ethPool();
         uint usmTotalSupply = totalSupply();
         uint oldDebtRatio = debtRatio(ethUsmPrice, ethInPool, usmTotalSupply);
@@ -187,7 +187,7 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
     function _fundFum(address to, uint minFumOut) internal returns (uint fumOut)
     {
         // 1. Refresh mfbp:
-        uint ethUsmPrice = latestPrice();
+        uint ethUsmPrice = cacheLatestPrice();
         uint rawEthInPool = ethPool();
         uint ethInPool = rawEthInPool.sub(msg.value);   // Backing out the ETH just received, which our calculations should ignore
         uint usmTotalSupply = totalSupply();
@@ -209,7 +209,7 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
     function _defundFum(address from, address payable to, uint fumToBurn, uint minEthOut) internal returns (uint ethOut)
     {
         // 1. Calculate ethOut:
-        uint ethUsmPrice = latestPrice();
+        uint ethUsmPrice = cacheLatestPrice();
         uint ethInPool = ethPool();
         uint usmTotalSupply = totalSupply();
         uint oldDebtRatio = debtRatio(ethUsmPrice, ethInPool, usmTotalSupply);

--- a/contracts/mocks/GasMeasuredMedianOracle.sol
+++ b/contracts/mocks/GasMeasuredMedianOracle.sol
@@ -10,13 +10,10 @@ contract GasMeasuredMedianOracle is MedianOracle, GasMeasuredOracle("median") {
     constructor(
         AggregatorV3Interface chainlinkAggregator,
         UniswapAnchoredView compoundView,
-        IUniswapV2Pair[NUM_UNISWAP_PAIRS] memory uniswapPairs,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens0Decimals,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens1Decimals,
-        bool[NUM_UNISWAP_PAIRS] memory uniswapTokensInReverseOrder
+        IUniswapV2Pair uniswapPair, uint uniswapToken0Decimals, uint uniswapToken1Decimals, bool uniswapTokensInReverseOrder
     ) public
         MedianOracle(chainlinkAggregator, compoundView,
-                     uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals, uniswapTokensInReverseOrder) {}
+                     uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
 
     function cacheLatestPrice() public override(Oracle, MedianOracle) returns (uint price) {
         price = MedianOracle.cacheLatestPrice();

--- a/contracts/mocks/GasMeasuredMedianOracle.sol
+++ b/contracts/mocks/GasMeasuredMedianOracle.sol
@@ -17,4 +17,8 @@ contract GasMeasuredMedianOracle is MedianOracle, GasMeasuredOracle("median") {
     ) public
         MedianOracle(chainlinkAggregator, compoundView,
                      uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals, uniswapTokensInReverseOrder) {}
+
+    function cacheLatestPrice() public override(Oracle, MedianOracle) returns (uint price) {
+        price = MedianOracle.cacheLatestPrice();
+    }
 }

--- a/contracts/mocks/GasMeasuredMedianOracle.sol
+++ b/contracts/mocks/GasMeasuredMedianOracle.sol
@@ -16,6 +16,6 @@ contract GasMeasuredMedianOracle is MedianOracle, GasMeasuredOracle("median") {
                      uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
 
     function cacheLatestPrice() public override(Oracle, MedianOracle) returns (uint price) {
-        price = MedianOracle.cacheLatestPrice();
+        price = super.cacheLatestPrice();
     }
 }

--- a/contracts/mocks/GasMeasuredOurUniswapV2TWAPOracle.sol
+++ b/contracts/mocks/GasMeasuredOurUniswapV2TWAPOracle.sol
@@ -9,6 +9,6 @@ contract GasMeasuredOurUniswapV2TWAPOracle is OurUniswapV2TWAPOracle, GasMeasure
         OurUniswapV2TWAPOracle(pair, token0Decimals, token1Decimals, tokensInReverseOrder) {}
 
     function cacheLatestPrice() public override(Oracle, OurUniswapV2TWAPOracle) returns (uint price) {
-        price = OurUniswapV2TWAPOracle.cacheLatestPrice();
+        price = super.cacheLatestPrice();
     }
 }

--- a/contracts/mocks/GasMeasuredOurUniswapV2TWAPOracle.sol
+++ b/contracts/mocks/GasMeasuredOurUniswapV2TWAPOracle.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.6;
+
+import "./GasMeasuredOracle.sol";
+import "../oracles/OurUniswapV2TWAPOracle.sol";
+
+contract GasMeasuredOurUniswapV2TWAPOracle is OurUniswapV2TWAPOracle, GasMeasuredOracle("uniswapTWAP") {
+    constructor(IUniswapV2Pair pair, uint token0Decimals, uint token1Decimals, bool tokensInReverseOrder) public
+        OurUniswapV2TWAPOracle(pair, token0Decimals, token1Decimals, tokensInReverseOrder) {}
+
+    function cacheLatestPrice() public override(Oracle, OurUniswapV2TWAPOracle) returns (uint price) {
+        price = OurUniswapV2TWAPOracle.cacheLatestPrice();
+    }
+}

--- a/contracts/mocks/GasMeasuredUniswapMedianSpotOracle.sol
+++ b/contracts/mocks/GasMeasuredUniswapMedianSpotOracle.sol
@@ -8,8 +8,8 @@ contract GasMeasuredUniswapMedianSpotOracle is UniswapMedianSpotOracle, GasMeasu
     uint private constant NUM_SOURCE_ORACLES = 3;
 
     constructor(IUniswapV2Pair[NUM_SOURCE_ORACLES] memory pairs,
-		uint[NUM_SOURCE_ORACLES] memory tokens0Decimals,
-		uint[NUM_SOURCE_ORACLES] memory tokens1Decimals,
-		bool[NUM_SOURCE_ORACLES] memory tokensInReverseOrder) public
+                uint[NUM_SOURCE_ORACLES] memory tokens0Decimals,
+                uint[NUM_SOURCE_ORACLES] memory tokens1Decimals,
+                bool[NUM_SOURCE_ORACLES] memory tokensInReverseOrder) public
         UniswapMedianSpotOracle(pairs, tokens0Decimals, tokens1Decimals, tokensInReverseOrder) {}
 }

--- a/contracts/mocks/GasMeasuredUniswapMedianTWAPOracle.sol
+++ b/contracts/mocks/GasMeasuredUniswapMedianTWAPOracle.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.6;
+
+import "./GasMeasuredOracle.sol";
+import "../oracles/UniswapMedianTWAPOracle.sol";
+
+contract GasMeasuredUniswapMedianTWAPOracle is UniswapMedianTWAPOracle, GasMeasuredOracle("uniswapMedianTWAP") {
+    uint private constant NUM_SOURCE_ORACLES = 3;
+
+    constructor(
+        IUniswapV2Pair[NUM_SOURCE_ORACLES] memory pairs,
+        uint[NUM_SOURCE_ORACLES] memory tokens0Decimals,
+        uint[NUM_SOURCE_ORACLES] memory tokens1Decimals,
+        bool[NUM_SOURCE_ORACLES] memory tokensInReverseOrder
+    ) public
+        UniswapMedianTWAPOracle(pairs, tokens0Decimals, tokens1Decimals, tokensInReverseOrder) {}
+
+    function cacheLatestPrice() public override(Oracle, UniswapMedianTWAPOracle) returns (uint price) {
+        price = UniswapMedianTWAPOracle.cacheLatestPrice();
+    }
+}

--- a/contracts/mocks/GasMeasuredUniswapMedianTWAPOracle.sol
+++ b/contracts/mocks/GasMeasuredUniswapMedianTWAPOracle.sol
@@ -16,6 +16,6 @@ contract GasMeasuredUniswapMedianTWAPOracle is UniswapMedianTWAPOracle, GasMeasu
         UniswapMedianTWAPOracle(pairs, tokens0Decimals, tokens1Decimals, tokensInReverseOrder) {}
 
     function cacheLatestPrice() public override(Oracle, UniswapMedianTWAPOracle) returns (uint price) {
-        price = UniswapMedianTWAPOracle.cacheLatestPrice();
+        price = super.cacheLatestPrice();
     }
 }

--- a/contracts/mocks/MockMedianOracleUSM.sol
+++ b/contracts/mocks/MockMedianOracleUSM.sol
@@ -30,8 +30,7 @@ contract MockMedianOracleUSM is USM, SettableOracle {
     }
 
     function cacheLatestPrice() public override(Oracle, USM) returns (uint price) {
-        USM.cacheLatestPrice();
-        price = latestPrice();
+        price = (savedPrice != 0) ? savedPrice : super.cacheLatestPrice();
     }
 
     function latestPrice() public override view returns (uint price) {

--- a/contracts/mocks/MockMedianOracleUSM.sol
+++ b/contracts/mocks/MockMedianOracleUSM.sol
@@ -29,6 +29,11 @@ contract MockMedianOracleUSM is USM, SettableOracle {
         savedPrice = p;
     }
 
+    function cacheLatestPrice() public override(Oracle, USM) returns (uint price) {
+        USM.cacheLatestPrice();
+        price = latestPrice();
+    }
+
     function latestPrice() public override view returns (uint price) {
         price = (savedPrice != 0) ? savedPrice : super.latestPrice();
     }

--- a/contracts/mocks/MockMedianOracleUSM.sol
+++ b/contracts/mocks/MockMedianOracleUSM.sol
@@ -17,13 +17,10 @@ contract MockMedianOracleUSM is USM, SettableOracle {
     constructor(
         AggregatorV3Interface chainlinkAggregator,
         UniswapAnchoredView compoundView,
-        IUniswapV2Pair[NUM_UNISWAP_PAIRS] memory uniswapPairs,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens0Decimals,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens1Decimals,
-        bool[NUM_UNISWAP_PAIRS] memory uniswapTokensInReverseOrder
+        IUniswapV2Pair uniswapPair, uint uniswapToken0Decimals, uint uniswapToken1Decimals, bool uniswapTokensInReverseOrder
     ) public
         USM(chainlinkAggregator, compoundView,
-            uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals, uniswapTokensInReverseOrder) {}
+            uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
 
     function setPrice(uint p) public override {
         savedPrice = p;

--- a/contracts/mocks/MockUniswapV2Pair.sol
+++ b/contracts/mocks/MockUniswapV2Pair.sol
@@ -4,13 +4,30 @@ pragma solidity ^0.6.6;
 contract MockUniswapV2Pair {
     uint112 internal _reserves0;
     uint112 internal _reserves1;
+    uint32 _blockTimestamp;
+    uint internal _price0CumulativeLast;
+    uint internal _price1CumulativeLast;
 
-    function set(uint112 reserves0, uint112 reserves1) external {
+    function setReserves(uint112 reserves0, uint112 reserves1, uint32 blockTimestamp) external {
         _reserves0 = reserves0;
         _reserves1 = reserves1;
+        _blockTimestamp = blockTimestamp;
     }
 
     function getReserves() external view returns (uint112, uint112, uint32) {
-        return (_reserves0, _reserves1, 0);
+        return (_reserves0, _reserves1, _blockTimestamp);
+    }
+
+    function setCumulativePrices(uint cumPrice0, uint cumPrice1) external {
+        _price0CumulativeLast = cumPrice0;
+        _price1CumulativeLast = cumPrice1;
+    }
+
+    function price0CumulativeLast() external view returns (uint) {
+        return _price0CumulativeLast;
+    }
+
+    function price1CumulativeLast() external view returns (uint) {
+        return _price1CumulativeLast;
     }
 }

--- a/contracts/oracles/MedianOracle.sol
+++ b/contracts/oracles/MedianOracle.sol
@@ -28,12 +28,14 @@ contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, UniswapMedianTWAPO
     function latestPrice() public override(ChainlinkOracle, CompoundOpenOracle, UniswapMedianTWAPOracle)
         view returns (uint price)
     {
-        price = Median.median(latestChainlinkPrice(),
-                              latestCompoundPrice(),
-                              latestUniswapMedianTWAPPrice());
+        price = Median.median(ChainlinkOracle.latestPrice(),
+                              CompoundOpenOracle.latestPrice(),
+                              UniswapMedianTWAPOracle.latestPrice());
     }
 
     function cacheLatestPrice() public virtual override(Oracle, UniswapMedianTWAPOracle) returns (uint price) {
-        price = UniswapMedianTWAPOracle.cacheLatestPrice();
+        price = Median.median(ChainlinkOracle.latestPrice(),                // Not ideal to call latestPrice() on two of these and
+                              CompoundOpenOracle.latestPrice(),             // cacheLatestPrice() on one...  But it works, and
+                              UniswapMedianTWAPOracle.cacheLatestPrice());  // inheriting them all like this saves significant gas
     }
 }

--- a/contracts/oracles/MedianOracle.sol
+++ b/contracts/oracles/MedianOracle.sol
@@ -30,8 +30,8 @@ contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, OurUniswapV2TWAPOr
     }
 
     function cacheLatestPrice() public virtual override(Oracle, OurUniswapV2TWAPOracle) returns (uint price) {
-        price = Median.median(ChainlinkOracle.latestPrice(),                // Not ideal to call latestPrice() on two of these and
-                              CompoundOpenOracle.latestPrice(),             // cacheLatestPrice() on one...  But it works, and
-                              OurUniswapV2TWAPOracle.cacheLatestPrice());   // inheriting them all like this saves significant gas
+        price = Median.median(ChainlinkOracle.latestPrice(),              // Not ideal to call latestPrice() on two of these
+                              CompoundOpenOracle.latestPrice(),           // and cacheLatestPrice() on one...  But works, and
+                              OurUniswapV2TWAPOracle.cacheLatestPrice()); // inheriting them like this saves significant gas
     }
 }

--- a/contracts/oracles/MedianOracle.sol
+++ b/contracts/oracles/MedianOracle.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.6.6;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./ChainlinkOracle.sol";
 import "./CompoundOpenOracle.sol";
-import "./UniswapMedianTWAPOracle.sol";
+import "./OurUniswapV2TWAPOracle.sol";
 import "./Median.sol";
 
-contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, UniswapMedianTWAPOracle {
+contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, OurUniswapV2TWAPOracle {
     using SafeMath for uint;
 
     uint private constant NUM_UNISWAP_PAIRS = 3;
@@ -15,27 +15,23 @@ contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, UniswapMedianTWAPO
     constructor(
         AggregatorV3Interface chainlinkAggregator,
         UniswapAnchoredView compoundView,
-        IUniswapV2Pair[NUM_UNISWAP_PAIRS] memory uniswapPairs,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens0Decimals,
-        uint[NUM_UNISWAP_PAIRS] memory uniswapTokens1Decimals,
-        bool[NUM_UNISWAP_PAIRS] memory uniswapTokensInReverseOrder
+        IUniswapV2Pair uniswapPair, uint uniswapToken0Decimals, uint uniswapToken1Decimals, bool uniswapTokensInReverseOrder
     ) public
         ChainlinkOracle(chainlinkAggregator)
         CompoundOpenOracle(compoundView)
-        UniswapMedianTWAPOracle(uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals,
-                                uniswapTokensInReverseOrder) {}
+        OurUniswapV2TWAPOracle(uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
 
-    function latestPrice() public override(ChainlinkOracle, CompoundOpenOracle, UniswapMedianTWAPOracle)
+    function latestPrice() public override(ChainlinkOracle, CompoundOpenOracle, OurUniswapV2TWAPOracle)
         view returns (uint price)
     {
         price = Median.median(ChainlinkOracle.latestPrice(),
                               CompoundOpenOracle.latestPrice(),
-                              UniswapMedianTWAPOracle.latestPrice());
+                              OurUniswapV2TWAPOracle.latestPrice());
     }
 
-    function cacheLatestPrice() public virtual override(Oracle, UniswapMedianTWAPOracle) returns (uint price) {
+    function cacheLatestPrice() public virtual override(Oracle, OurUniswapV2TWAPOracle) returns (uint price) {
         price = Median.median(ChainlinkOracle.latestPrice(),                // Not ideal to call latestPrice() on two of these and
                               CompoundOpenOracle.latestPrice(),             // cacheLatestPrice() on one...  But it works, and
-                              UniswapMedianTWAPOracle.cacheLatestPrice());  // inheriting them all like this saves significant gas
+                              OurUniswapV2TWAPOracle.cacheLatestPrice());   // inheriting them all like this saves significant gas
     }
 }

--- a/contracts/oracles/MedianOracle.sol
+++ b/contracts/oracles/MedianOracle.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.6.6;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./ChainlinkOracle.sol";
 import "./CompoundOpenOracle.sol";
-import "./UniswapMedianSpotOracle.sol";
+import "./UniswapMedianTWAPOracle.sol";
 import "./Median.sol";
 
-contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, UniswapMedianSpotOracle {
+contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, UniswapMedianTWAPOracle {
     using SafeMath for uint;
 
     uint private constant NUM_UNISWAP_PAIRS = 3;
@@ -22,14 +22,18 @@ contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, UniswapMedianSpotO
     ) public
         ChainlinkOracle(chainlinkAggregator)
         CompoundOpenOracle(compoundView)
-        UniswapMedianSpotOracle(uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals,
+        UniswapMedianTWAPOracle(uniswapPairs, uniswapTokens0Decimals, uniswapTokens1Decimals,
                                 uniswapTokensInReverseOrder) {}
 
-    function latestPrice() public override(ChainlinkOracle, CompoundOpenOracle, UniswapMedianSpotOracle)
+    function latestPrice() public override(ChainlinkOracle, CompoundOpenOracle, UniswapMedianTWAPOracle)
         view returns (uint price)
     {
         price = Median.median(latestChainlinkPrice(),
                               latestCompoundPrice(),
-                              latestUniswapMedianSpotPrice());
+                              latestUniswapMedianTWAPPrice());
+    }
+
+    function cacheLatestPrice() public virtual override(Oracle, UniswapMedianTWAPOracle) returns (uint price) {
+        price = UniswapMedianTWAPOracle.cacheLatestPrice();
     }
 }

--- a/contracts/oracles/Oracle.sol
+++ b/contracts/oracles/Oracle.sol
@@ -6,8 +6,8 @@ abstract contract Oracle {
 
     /**
      * @dev This pure virtual implementation, which is intended to be (optionally) overridden by stateful implementations,
-     * confuses solhint into giving a "Function state mutability can be restricted to view" warning.  Unfortunately there seems to
-     * be no elegant/gas-free workaround as yet: see https://github.com/ethereum/solidity/issues/3529.
+     * confuses solhint into giving a "Function state mutability can be restricted to view" warning.  Unfortunately there seems
+     * to be no elegant/gas-free workaround as yet: see https://github.com/ethereum/solidity/issues/3529.
      */
     function cacheLatestPrice() public virtual returns (uint price) {
         price = latestPrice();  // Default implementation doesn't do any cacheing, just returns price.  But override as needed

--- a/contracts/oracles/Oracle.sol
+++ b/contracts/oracles/Oracle.sol
@@ -2,5 +2,14 @@
 pragma solidity ^0.6.6;
 
 abstract contract Oracle {
-    function latestPrice() public virtual view returns (uint);      // Prices must be WAD-scaled - 18 decimal places
+    function latestPrice() public virtual view returns (uint price);    // Prices must be WAD-scaled - 18 decimal places
+
+    /**
+     * @dev This pure virtual implementation, which is intended to be (optionally) overridden by stateful implementations,
+     * confuses solhint into giving a "Function state mutability can be restricted to view" warning.  Unfortunately there seems to
+     * be no elegant/gas-free workaround as yet: see https://github.com/ethereum/solidity/issues/3529.
+     */
+    function cacheLatestPrice() public virtual returns (uint price) {
+        price = latestPrice();  // Default implementation doesn't do any cacheing, just returns price.  But override as needed
+    }
 }

--- a/contracts/oracles/OurUniswap.sol
+++ b/contracts/oracles/OurUniswap.sol
@@ -62,7 +62,7 @@ library OurUniswap {
         // Retrieve the current Uniswap cumulative price.  Modeled off of Uniswap's own example:
         // https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/examples/ExampleOracleSimple.sol
         uint uniswapCumPrice = pair.tokensInReverseOrder ?
-	    pair.uniswapPair.price1CumulativeLast() :
+            pair.uniswapPair.price1CumulativeLast() :
             pair.uniswapPair.price0CumulativeLast();
         priceSeconds = uniswapCumPrice.mul(pair.scaleFactor) / UNISWAP_CUM_PRICE_SCALE_FACTOR;
     }

--- a/contracts/oracles/OurUniswap.sol
+++ b/contracts/oracles/OurUniswap.sol
@@ -50,9 +50,9 @@ library OurUniswap {
     /**
      * @return timestamp Timestamp at which Uniswap stored the priceSeconds.
      * @return priceSeconds The pair's cumulative "price-seconds", using Uniswap's TWAP logic.  Eg, if at time t0
-     * priceSeconds = 10,000,000 (returned here as 10,000,000 * 10**18, ie, in WAD fixed-point format), and during the 30 seconds
-     * between t0 and t1 = t0 + 30, the price is $45.67, then at time t1, priceSeconds = 10,000,000 + 30 * 45.67 = 10,001,370.1
-     * (stored as 10,001,370.1 * 10**18).
+     * priceSeconds = 10,000,000 (returned here as 10,000,000 * 10**18, ie, in WAD fixed-point format), and during the 30
+     * seconds between t0 and t1 = t0 + 30, the price is $45.67, then at time t1, priceSeconds = 10,000,000 + 30 * 45.67 =
+     * 10,001,370.1 (stored as 10,001,370.1 * 10**18).
      */
     function cumulativePrice(Pair storage pair)
         internal view returns (uint timestamp, uint priceSeconds)

--- a/contracts/oracles/OurUniswap.sol
+++ b/contracts/oracles/OurUniswap.sol
@@ -7,6 +7,9 @@ import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 library OurUniswap {
     using SafeMath for uint;
 
+    // Uniswap stores its cumulative prices in "FixedPoint.uq112x112" format - 112-bit fixed point:
+    uint public constant UNISWAP_CUM_PRICE_SCALE_FACTOR = 2 ** 112;
+
     struct Pair {
         IUniswapV2Pair uniswapPair;
         uint token0Decimals;
@@ -42,5 +45,38 @@ library OurUniswap {
             (uint(reserve1), uint(reserve0)) :
             (uint(reserve0), uint(reserve1));
         price = reserveB.mul(pair.scaleFactor).div(reserveA);
+    }
+
+    /**
+     * @return timestamp Timestamp at which Uniswap stored the priceSeconds.
+     * @return priceSeconds The pair's cumulative "price-seconds", using Uniswap's TWAP logic.  Eg, if at time t0
+     * priceSeconds = 10,000,000 (returned here as 10,000,000 * 10**18, ie, in WAD fixed-point format), and during the 30 seconds
+     * between t0 and t1 = t0 + 30, the price is $45.67, then at time t1, priceSeconds = 10,000,000 + 30 * 45.67 = 10,001,370.1
+     * (stored as 10,001,370.1 * 10**18).
+     */
+    function cumulativePrice(Pair storage pair)
+        internal view returns (uint timestamp, uint priceSeconds)
+    {
+        (, , timestamp) = pair.uniswapPair.getReserves();
+
+        // Retrieve the current Uniswap cumulative price.  Modeled off of Uniswap's own example:
+        // https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/examples/ExampleOracleSimple.sol
+        uint uniswapCumPrice = pair.tokensInReverseOrder ?
+	    pair.uniswapPair.price1CumulativeLast() :
+            pair.uniswapPair.price0CumulativeLast();
+        priceSeconds = uniswapCumPrice.mul(pair.scaleFactor) / UNISWAP_CUM_PRICE_SCALE_FACTOR;
+    }
+
+    /**
+     * @param oldTimestamp in seconds (eg, 1606764888) - not WAD-scaled!
+     * @param oldPriceSeconds WAD-scaled.
+     * @param newTimestamp in raw seconds again.
+     * @param newPriceSeconds WAD-scaled.
+     * @return price WAD-scaled.
+     */
+    function calculateTWAP(uint newTimestamp, uint newPriceSeconds, uint oldTimestamp, uint oldPriceSeconds)
+        internal pure returns (uint price)
+    {
+        price = (newPriceSeconds.sub(oldPriceSeconds)).div(newTimestamp.sub(oldTimestamp));
     }
 }

--- a/contracts/oracles/OurUniswap.sol
+++ b/contracts/oracles/OurUniswap.sol
@@ -68,10 +68,10 @@ library OurUniswap {
     }
 
     /**
-     * @param oldTimestamp in seconds (eg, 1606764888) - not WAD-scaled!
-     * @param oldPriceSeconds WAD-scaled.
-     * @param newTimestamp in raw seconds again.
+     * @param newTimestamp in seconds (eg, 1606764888) - not WAD-scaled!
      * @param newPriceSeconds WAD-scaled.
+     * @param oldTimestamp in raw seconds again.
+     * @param oldPriceSeconds WAD-scaled.
      * @return price WAD-scaled.
      */
     function calculateTWAP(uint newTimestamp, uint newPriceSeconds, uint oldTimestamp, uint oldPriceSeconds)

--- a/contracts/oracles/OurUniswapV2SpotOracle.sol
+++ b/contracts/oracles/OurUniswapV2SpotOracle.sol
@@ -26,7 +26,7 @@ contract OurUniswapV2SpotOracle is Oracle {
         price = OurUniswap.spotPrice(pair);
     }
 
-    function latestUniswapPrice() public view returns (uint price) {
+    function latestUniswapSpotPrice() public view returns (uint price) {
         price = OurUniswap.spotPrice(pair);
     }
 }

--- a/contracts/oracles/OurUniswapV2TWAPOracle.sol
+++ b/contracts/oracles/OurUniswapV2TWAPOracle.sol
@@ -56,10 +56,10 @@ contract OurUniswapV2TWAPOracle is Oracle {
     }
 
     function latestPrice() public virtual override view returns (uint price) {
-        price = latestUniswapPrice();
+        price = latestUniswapTWAPPrice();
     }
 
-    function latestUniswapPrice() public view returns (uint price) {
+    function latestUniswapTWAPPrice() public view returns (uint price) {
         CumulativePrice storage newerStoredPrice;
         (, newerStoredPrice) = orderedStoredPrices();
         (price, , ) = _latestPrice(newerStoredPrice);

--- a/contracts/oracles/OurUniswapV2TWAPOracle.sol
+++ b/contracts/oracles/OurUniswapV2TWAPOracle.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.6;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
+import "./Oracle.sol";
+import "./OurUniswap.sol";
+
+contract OurUniswapV2TWAPOracle is Oracle {
+    using SafeMath for uint;
+
+    uint public constant UINT32_MAX = 2 ** 32 - 1;      // This should really be type(uint32).max, but requires Solidity 0.6.8...
+    uint public constant UINT224_MAX = 2 ** 224 - 1;    // Ditto, type(uint224).max
+
+    /**
+     * MIN_TWAP_PERIOD plays two roles:
+     *
+     * 1. Minimum age of the stored CumulativePrice we calculate our current TWAP vs.  Eg, if one of our stored prices is from 5
+     * secs ago, and the other from 10 min ago, we should calculate TWAP vs the 10-min-old one, since a 5-second TWAP is too
+     * short - relatively easy to manipulate.
+     *
+     * 2. Minimum time gap between stored CumulativePrices.  Eg, if we stored one 5 seconds ago, we don't need to store another
+     * one now - and shouldn't, since then if someone else made a TWAP call a few seconds later, both stored prices would be too
+     * recent to calculate a robust TWAP.
+     *
+     * These roles could in principle be separated, eg: "Require the stored price we calculate TWAP from to be >= 2 minutes old,
+     * but leave >= 10 minutes before storing a new price."  But for simplicity we keep them the same.
+     */
+    uint public constant MIN_TWAP_PERIOD = 2 minutes;
+
+    struct CumulativePrice {
+        uint32 timestamp;
+        uint224 priceSeconds;   // See OurUniswap.cumulativePrice() for an explanation of "priceSeconds"
+    }
+
+    OurUniswap.Pair private pair;
+
+    CumulativePrice private storedPriceA;
+    CumulativePrice private storedPriceB;
+
+    /**
+     * See OurUniswapV2SpotOracle for example pairs to pass in.
+     */
+    constructor(IUniswapV2Pair uniswapPair, uint token0Decimals, uint token1Decimals, bool tokensInReverseOrder) public {
+        pair = OurUniswap.createPair(uniswapPair, token0Decimals, token1Decimals, tokensInReverseOrder);
+    }
+
+    function cacheLatestPrice() public virtual override returns (uint price) {
+        (CumulativePrice storage olderStoredPrice, CumulativePrice storage newerStoredPrice) = orderedStoredPrices();
+
+        uint timestamp;
+        uint priceSeconds;
+        (price, timestamp, priceSeconds) = _latestPrice(newerStoredPrice);
+
+        storePriceIfLatestStoredPriceIsStale(timestamp, priceSeconds, olderStoredPrice, newerStoredPrice);
+    }
+
+    function latestPrice() public virtual override view returns (uint price) {
+        price = latestUniswapPrice();
+    }
+
+    function latestUniswapPrice() public view returns (uint price) {
+        CumulativePrice storage newerStoredPrice;
+        (, newerStoredPrice) = orderedStoredPrices();
+        (price, , ) = _latestPrice(newerStoredPrice);
+    }
+
+    function _latestPrice(CumulativePrice storage newerStoredPrice)
+        internal view returns (uint price, uint timestamp, uint priceSeconds)
+    {
+        (timestamp, priceSeconds) = OurUniswap.cumulativePrice(pair);
+
+        // Now that we have the current cum price, subtract-&-divide the stored one, to get the TWAP price:
+        CumulativePrice storage refPrice = storedPriceToCompareVs(timestamp, newerStoredPrice);
+        price = OurUniswap.calculateTWAP(timestamp, priceSeconds, uint(refPrice.timestamp), uint(refPrice.priceSeconds));
+    }
+
+    function storePriceIfLatestStoredPriceIsStale(
+        uint timestamp, uint priceSeconds,
+        CumulativePrice storage olderStoredPrice, CumulativePrice storage newerStoredPrice
+    ) internal
+    {
+        // Store the latest price, if it's been long enough since the latest stored price:
+        if (areNewAndStoredPriceFarEnoughApart(timestamp, newerStoredPrice)) {
+            require(timestamp <= UINT32_MAX, "timestamp overflow");
+            require(priceSeconds <= UINT224_MAX, "priceSeconds overflow");
+            // This assignment is only persistent because older has modifier "storage" - ie, store by reference!
+            (olderStoredPrice.timestamp, olderStoredPrice.priceSeconds) = (uint32(timestamp), uint224(priceSeconds));
+        }
+    }
+
+    function storedPriceToCompareVs(uint newTimestamp, CumulativePrice storage newerStoredPrice)
+        internal view returns (CumulativePrice storage refPrice)
+    {
+        bool aAcceptable = areNewAndStoredPriceFarEnoughApart(newTimestamp, storedPriceA);
+        bool bAcceptable = areNewAndStoredPriceFarEnoughApart(newTimestamp, storedPriceB);
+        if (aAcceptable && bAcceptable) {
+            refPrice = newerStoredPrice;        // Neither is *too* recent, so return the fresher of the two
+        } else if (aAcceptable) {
+            refPrice = storedPriceA;            // Only A is acceptable
+        } else if (bAcceptable) {
+            refPrice = storedPriceB;            // Only B is acceptable
+        } else {
+            revert("Both stored prices too recent");
+        }
+    }
+
+    function orderedStoredPrices() internal view
+        returns (CumulativePrice storage olderStoredPrice, CumulativePrice storage newerStoredPrice)
+    {
+        (olderStoredPrice, newerStoredPrice) = storedPriceB.timestamp > storedPriceA.timestamp ?
+            (storedPriceA, storedPriceB) : (storedPriceB, storedPriceA);
+    }
+
+    function areNewAndStoredPriceFarEnoughApart(uint newTimestamp, CumulativePrice storage storedPrice) internal view
+        returns (bool farEnough)
+    {
+        farEnough = newTimestamp >= (uint(storedPrice.timestamp)).add(MIN_TWAP_PERIOD);
+    }
+}

--- a/contracts/oracles/UniswapMedianTWAPOracle.sol
+++ b/contracts/oracles/UniswapMedianTWAPOracle.sol
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.6;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
+import "./Oracle.sol";
+import "./OurUniswap.sol";
+import "./Median.sol";
+
+contract UniswapMedianTWAPOracle is Oracle {
+    using SafeMath for uint;
+
+    uint private constant WAD = 10 ** 18;
+    uint private constant WAD_OVER_100 = WAD / 100;
+    uint private constant UINT32_MAX = 2 ** 32 - 1;      // This should really be type(uint32).max, but requires Solidity 0.6.8...
+    uint private constant TWO_TO_THE_48 = 2 ** 48;       // See below for how we use this
+    uint private constant MAX_PRICE_SECONDS_CHANGE_WE_CAN_STORE = TWO_TO_THE_48 * WAD_OVER_100; // See unpackPriceSeconds()
+
+    uint private constant NUM_SOURCE_ORACLES = 3;
+
+    // Minimum age of the stored CumulativePrices we calculate our TWAP vs, and minimum gap between stored CumulativePrices.  See
+    // also the more detailed explanation in OurUniswapV2TWAPOracle.
+    uint private constant MIN_TWAP_PERIOD = 2 minutes;
+
+    // Each CumulativePrices struct crams three pairs timestamps and cumulative prices ("price-seconds") into one 256-bit word.
+    struct CumulativePrices {
+        uint32 timestamp1;
+        // priceSeconds = the pair's cumulative number of "price-seconds".  Eg, if at time t0 priceSeconds = 10,000,000 (stored as
+        // 10,000,000 * 100 = 1,000,000,000), and during the 30 seconds between t0 and t1 = t0 + 30, the price is $45.67, then at
+        // time t1 priceSeconds = 10,000,000 + 30 * 45.67 = 10,001,370.1 (stored as 10,001,370.1 * 100 = 1,000,137,010).  This is
+        // just how Uniswap v2 TWAP prices work, we're just converting to 100-scaled ("pennies") format.  See also the WAD-scaled
+        // version in OurUniswapV2TWAPOracle.
+        uint48 priceSeconds1;
+        uint32 timestamp2;
+        uint48 priceSeconds2;
+        uint32 timestamp3;
+        uint48 priceSeconds3;
+    }
+
+    OurUniswap.Pair[NUM_SOURCE_ORACLES] private pairs;
+
+    /**
+     * We store two CumulativePrices, A and B, without specifying which is more recent.  This is so that we only need to do one
+     * SSTORE each time we save a new one: we can inspect them later to figure out which is newer - see orderedStoredPrices().
+     */
+    CumulativePrices private storedPricesA;
+    CumulativePrices private storedPricesB;
+
+    /* ____________________ Constructor ____________________ */
+
+    /**
+     * See OurUniswapV2SpotOracle for example pairs to pass in
+     */
+    constructor(IUniswapV2Pair[NUM_SOURCE_ORACLES] memory uniswapPairs,
+                uint[NUM_SOURCE_ORACLES] memory tokens0Decimals,
+                uint[NUM_SOURCE_ORACLES] memory tokens1Decimals,
+                bool[NUM_SOURCE_ORACLES] memory tokensInReverseOrder) public
+    {
+        for (uint i = 0; i < NUM_SOURCE_ORACLES; ++i) {
+            pairs[i] = OurUniswap.createPair(uniswapPairs[i], tokens0Decimals[i], tokens1Decimals[i], tokensInReverseOrder[i]);
+        }
+    }
+
+    /* ____________________ Public stateful functions ____________________ */
+
+    function cacheLatestPrice() public virtual override returns (uint price) {
+        (CumulativePrices storage olderStoredPrices, CumulativePrices storage newerStoredPrices) = orderedStoredPrices();
+
+        uint[NUM_SOURCE_ORACLES] memory prices;
+        uint[NUM_SOURCE_ORACLES] memory timestamps;
+        uint[NUM_SOURCE_ORACLES] memory priceSeconds;
+        (price, prices, timestamps, priceSeconds) = latestPrices(newerStoredPrices);
+
+        if (areNewAndStoredPricesFarEnoughApart(timestamps, newerStoredPrices)) {
+            storeCumulativePrices(timestamps, priceSeconds, olderStoredPrices);
+        }
+    }
+
+    /* ____________________ Public view functions ____________________ */
+
+    function latestPrice() public virtual override view returns (uint price) {
+        price = latestUniswapMedianTWAPPrice();
+    }
+
+    function latestUniswapMedianTWAPPrice() public view returns (uint price) {
+        (, CumulativePrices storage newerStoredPrices) = orderedStoredPrices();
+        (price, , , ) = latestPrices(newerStoredPrices);
+    }
+
+    function latestUniswapPair1TWAPPrice() public view returns (uint price) {
+        (, CumulativePrices storage newerStoredPrices) = orderedStoredPrices();
+        (, uint[NUM_SOURCE_ORACLES] memory prices, , ) = latestPrices(newerStoredPrices);
+        price = prices[0];
+    }
+
+    function latestUniswapPair2TWAPPrice() public view returns (uint price) {
+        (, CumulativePrices storage newerStoredPrices) = orderedStoredPrices();
+        (, uint[NUM_SOURCE_ORACLES] memory prices, , ) = latestPrices(newerStoredPrices);
+        price = prices[1];
+    }
+
+    function latestUniswapPair3TWAPPrice() public view returns (uint price) {
+        (, CumulativePrices storage newerStoredPrices) = orderedStoredPrices();
+        (, uint[NUM_SOURCE_ORACLES] memory prices, , ) = latestPrices(newerStoredPrices);
+        price = prices[2];
+    }
+
+    /* ____________________ Internal stateful functions ____________________ */
+
+    function storeCumulativePrices(uint[NUM_SOURCE_ORACLES] memory timestamps,
+                                   uint[NUM_SOURCE_ORACLES] memory priceSeconds,
+                                   CumulativePrices storage olderStoredPrices)
+        internal
+    {
+        for (uint i = 0; i < NUM_SOURCE_ORACLES; ++i) {
+            require(timestamps[i] <= UINT32_MAX, "timestamp overflow");
+        }
+
+        // We need to make the priceSeconds representation more compact than our usual WAD fixed-point decimal, in order to pack
+        // our update into a single 256-bit-word SSTORE.  So we store in "pennies" (2-decimal-place precision, rather than
+        // 18-decimal-place).  This still gives quite accurate ETH *prices*: to within around $0.0001.
+        // We also do "% TWO_TO_THE_48", rather than die on larger priceSeconds values with an overflow - see unpackPriceSeconds()
+        // below for how we avoid overflow (reasonably) safely.
+        // (Note: this assignment is only persistent because olderStoredPrices has modifier "storage" - ie, store by reference!)
+        olderStoredPrices.timestamp1 = uint32(timestamps[0]);
+        olderStoredPrices.timestamp2 = uint32(timestamps[1]);
+        olderStoredPrices.timestamp3 = uint32(timestamps[2]);
+        olderStoredPrices.priceSeconds1 = uint48((priceSeconds[0] / WAD_OVER_100) % TWO_TO_THE_48);
+        olderStoredPrices.priceSeconds2 = uint48((priceSeconds[1] / WAD_OVER_100) % TWO_TO_THE_48);
+        olderStoredPrices.priceSeconds3 = uint48((priceSeconds[2] / WAD_OVER_100) % TWO_TO_THE_48);
+    }
+
+    /* ____________________ Internal view functions ____________________ */
+
+    function latestPrices(CumulativePrices storage newerStoredPrices) internal view
+        returns (uint medianPrice,
+                 uint[NUM_SOURCE_ORACLES] memory prices,
+                 uint[NUM_SOURCE_ORACLES] memory timestamps,
+                 uint[NUM_SOURCE_ORACLES] memory priceSeconds)
+    {
+        for (uint i = 0; i < NUM_SOURCE_ORACLES; ++i) {
+            (timestamps[i], priceSeconds[i]) = OurUniswap.cumulativePrice(pairs[i]);
+        }
+
+        CumulativePrices storage refPrices = storedPricesToCompareVs(timestamps, newerStoredPrices);
+        (uint[NUM_SOURCE_ORACLES] memory storedTimestamps, uint[NUM_SOURCE_ORACLES] memory storedPriceSeconds) =
+            unpackStoredPrices(refPrices, priceSeconds);
+
+        for (uint i = 0; i < NUM_SOURCE_ORACLES; ++i) {
+            prices[i] = OurUniswap.calculateTWAP(timestamps[i], priceSeconds[i], storedTimestamps[i], storedPriceSeconds[i]);
+        }
+        medianPrice = Median.median(prices[0], prices[1], prices[2]);
+    }
+
+    function storedPricesToCompareVs(uint[NUM_SOURCE_ORACLES] memory newTimestamps, CumulativePrices storage newerStoredPrices)
+        internal view returns (CumulativePrices storage refPrices)
+    {
+        bool aAcceptable = areNewAndStoredPricesFarEnoughApart(newTimestamps, storedPricesA);
+        bool bAcceptable = areNewAndStoredPricesFarEnoughApart(newTimestamps, storedPricesB);
+
+        if (aAcceptable && bAcceptable) {
+            refPrices = newerStoredPrices;      // Neither is *too* recent, so return the fresher of the two
+        } else if (aAcceptable) {
+            refPrices = storedPricesA;          // Only A is acceptable
+        } else if (bAcceptable) {
+            refPrices = storedPricesB;          // Only B is acceptable
+        } else {
+            revert("Both stored prices too recent");
+        }
+    }
+
+    /**
+     * @return olderStoredPrices The older of the two stored CumulativePrices.
+     * @return newerStoredPrices The newer of the two.
+     */
+    function orderedStoredPrices() internal view
+        returns (CumulativePrices storage olderStoredPrices, CumulativePrices storage newerStoredPrices)
+    {
+        // Because we only store a new CumulativePrices if its three timestamps are *all* > those of the other stored
+        // CumulativePrices, we can check which is newer by just comparing the first timestamp in each:
+        (olderStoredPrices, newerStoredPrices) = storedPricesB.timestamp1 > storedPricesA.timestamp1 ?
+            (storedPricesA, storedPricesB) : (storedPricesB, storedPricesA);
+    }
+
+    /* ____________________ Internal pure functions ____________________ */
+
+    /**
+     * @notice New prices should only be stored if all three of the new timestamps are >= MIN_TWAP_PERIOD fresher than their
+     * corresponding latest stored timestamps: that is, we never want to store two cumulative prices < MIN_TWAP_PERIOD apart.
+     */
+    function areNewAndStoredPricesFarEnoughApart(uint[NUM_SOURCE_ORACLES] memory newTimestamps,
+                                                 CumulativePrices storage storedPrices) internal view
+        returns (bool farEnough)
+    {
+        farEnough = ((newTimestamps[0] >= (uint(storedPrices.timestamp1)).add(MIN_TWAP_PERIOD)) &&
+                     (newTimestamps[1] >= (uint(storedPrices.timestamp2)).add(MIN_TWAP_PERIOD)) &&
+                     (newTimestamps[2] >= (uint(storedPrices.timestamp3)).add(MIN_TWAP_PERIOD)));
+    }
+
+    /**
+     * @notice Unpacks the compact stored CumulativePrices format (uint32s and uint48s) into regular WAD-scaled uints.
+     */
+    function unpackStoredPrices(CumulativePrices storage storedPrices, uint[NUM_SOURCE_ORACLES] memory latestPriceSeconds)
+        internal view
+        returns (uint[NUM_SOURCE_ORACLES] memory storedTimestamps, uint[NUM_SOURCE_ORACLES] memory storedPriceSeconds)
+    {
+        storedTimestamps[0] = storedPrices.timestamp1;
+        storedTimestamps[1] = storedPrices.timestamp2;
+        storedTimestamps[2] = storedPrices.timestamp3;
+
+        // Convert the 100-scaled uint48 stored priceSeconds (eg, 58132, representing $581.32) into our usual WAD fixed-point
+        // format (eg, 581.32 * 10**18):
+        storedPriceSeconds[0] = unpackPriceSeconds(storedPrices.priceSeconds1, latestPriceSeconds[0]);
+        storedPriceSeconds[1] = unpackPriceSeconds(storedPrices.priceSeconds2, latestPriceSeconds[1]);
+        storedPriceSeconds[2] = unpackPriceSeconds(storedPrices.priceSeconds3, latestPriceSeconds[2]);
+    }
+
+    /**
+     * @notice Unpacks a 100-scaled uint48 stored priceSeconds value (eg, 88358132, representing $882,581.32) into our usual WAD
+     * fixed-point format (eg, 882,581.32 * 10**18).  The easy part here is multiplying by (10**18 / 100), but we also make an
+     * adjustment if needed to account for the fact that we only store priceSeconds mod 2**48.  Here's an intuitive example using
+     * decimals:
+     *
+     * Suppose we were storing priceSeconds % (10**6), ie, only the last 6 digits of the cumulative price.  As long as the stored
+     * priceSeconds is < 1,000,000, the stored price = the actual price.  But suppose we have a stored priceSeconds of 998,621,
+     * and also see that the latest priceSeconds from Uniswap is 23,000,067.  Then we can infer that the stored 998,621 probably
+     * represents 22,998,621, not 998,621.  This is the adjustment we make below.
+     *
+     * Of course, we're making an assumption here: that the actual difference between the stored priceSeconds and Uniswap's latest
+     * priceSeconds will never exceed the max value we can store (999,999 in the intuitive example above, 2**48 - 1 in our actual
+     * code below).  This is a reasonable assumption though: a one-month gap between updates, during which ETH was priced at
+     * $1,000,000, would still add less than 2**48 to priceSeconds.
+     *
+     * Without this adjustment, we'd be assuming not just that the *difference* between successive updates will always be < 2**48,
+     * but that the priceSeconds value *itself* will always be < 2**48.  This would be a significantly shakier assumption.
+     */
+    function unpackPriceSeconds(uint48 storedPriceSeconds, uint latestPriceSeconds) internal pure returns (uint priceSeconds) {
+        // First, convert to WAD format:
+        priceSeconds = storedPriceSeconds * WAD_OVER_100;
+
+        // Now, if priceSeconds is still more than MAX_PRICE_SECONDS_CHANGE_WE_CAN_STORE lower than latestPriceSeconds, adjust it:
+        if (latestPriceSeconds >= priceSeconds + MAX_PRICE_SECONDS_CHANGE_WE_CAN_STORE) {
+            // Following the intuitive example above: how do we calculate 22,998,621 from 23,000,067?  As follows:
+            // 23,000,067 - ((23,000,067 - 998,621) % 1,000,000) = 22,998,621.
+            priceSeconds = latestPriceSeconds - ((latestPriceSeconds - priceSeconds) % MAX_PRICE_SECONDS_CHANGE_WE_CAN_STORE);
+        }
+    }
+}

--- a/migrations/2_deploy_usmfum.js
+++ b/migrations/2_deploy_usmfum.js
@@ -5,7 +5,7 @@ const MockUniswapV2Pair = artifacts.require('MockUniswapV2Pair')
 const USM = artifacts.require('USM')
 
 module.exports = async function(deployer, network) {
-    
+
     const chainlinkAddresses = {
         'mainnet' : '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419',
         'mainnet-ganache' : '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419'
@@ -14,18 +14,18 @@ module.exports = async function(deployer, network) {
         'mainnet' : '0x922018674c12a7f0d394ebeef9b58f186cde13c1',
         'mainnet-ganache' : '0x922018674c12a7f0d394ebeef9b58f186cde13c1'
     }
-    const ethUsdtAddresses = {
-        'mainnet' : '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
-        'mainnet-ganache' : '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852'
-    }
+    //const ethUsdtAddresses = {
+    //    'mainnet' : '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+    //    'mainnet-ganache' : '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852'
+    //}
     const usdcEthAddresses = {
         'mainnet' : '0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc',
         'mainnet-ganache' : '0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc'
     }
-    const daiEthAddresses = {
-        'mainnet' : '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11',
-        'mainnet-ganache' : '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11'
-    }
+    //const daiEthAddresses = {
+    //    'mainnet' : '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11',
+    //    'mainnet-ganache' : '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11'
+    //}
     const wethAddresses = {
         'mainnet' : '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
         'mainnet-ganache' : '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
@@ -33,11 +33,14 @@ module.exports = async function(deployer, network) {
 
     const e30 = '1000000000000000000000000000000'
     const e18 = '1000000000000000000'
-    let weth, aggregator, anchoredView, ethUsdtPair, usdcEthPair, daiEthPair
-    let wethAddress, aggregatorAddress, anchoredViewAddress, ethUsdtPairAddress, usdcEthPairAddress, daiEthPairAddress
-    const uniswapTokens0Decimals = [18, 6, 18]                // See UniswapMedianOracle
-    const uniswapTokens1Decimals = [6, 18, 18]                // See UniswapMedianOracle
-    const uniswapTokensInReverseOrder = [false, true, true]   // See UniswapMedianOracle
+    let weth, aggregator, anchoredView, usdcEthPair
+    let wethAddress, aggregatorAddress, anchoredViewAddress, usdcEthPairAddress
+    //const uniswapTokens0Decimals = [18, 6, 18]                // See UniswapMedianOracle
+    //const uniswapTokens1Decimals = [6, 18, 18]                // See UniswapMedianOracle
+    //const uniswapTokensInReverseOrder = [false, true, true]   // See UniswapMedianOracle
+    const usdcDecimals = 6                                      // See UniswapMedianOracle
+    const ethDecimals = 18                                      // See UniswapMedianOracle
+    const uniswapTokensInReverseOrder = true                    // See UniswapMedianOracle
 
     if (network === 'development') {
         await deployer.deploy(WETH9);
@@ -46,54 +49,35 @@ module.exports = async function(deployer, network) {
 
         const chainlinkPrice = '38598000000' // 8 dec places: see ChainlinkOracle
         const compoundPrice = '414174999' // 6 dec places: see CompoundOpenOracle
-      
-        const ethUsdtReserve0 = '646310144553926227215994'
-        const ethUsdtReserve1 = '254384028636585'
-      
+
         const usdcEthReserve0 = '260787673159143'
         const usdcEthReserve1 = '696170744128378724814084'
-      
-        const daiEthReserve0 = '178617913077721329213551886'
-        const daiEthReserve1 = '480578265664207487333589'
 
         await deployer.deploy(MockAggregator)
         aggregator = await MockAggregator.deployed()
         await aggregator.set(chainlinkPrice)
         aggregatorAddress = aggregator.address
-    
+
         await deployer.deploy(MockUniswapAnchoredView)
         anchoredView = await MockUniswapAnchoredView.deployed()
         await anchoredView.set(compoundPrice)
         anchoredViewAddress = anchoredView.address
-    
-        await deployer.deploy(MockUniswapV2Pair)
-        ethUsdtPair = await MockUniswapV2Pair.deployed()
-        await ethUsdtPair.set(ethUsdtReserve0, ethUsdtReserve1)
-        ethUsdtPairAddress = ethUsdtPair.address
-  
+
         await deployer.deploy(MockUniswapV2Pair)
         usdcEthPair = await MockUniswapV2Pair.deployed()
         await usdcEthPair.set(usdcEthReserve0, usdcEthReserve1)
         usdcEthPairAddress = usdcEthPair.address
-  
-        await deployer.deploy(MockUniswapV2Pair)
-        daiEthPair = await MockUniswapV2Pair.deployed()
-        await daiEthPair.set(daiEthReserve0, daiEthReserve1)
-        daiEthPairAddress = daiEthPair.address
     }
     else {
         wethAddress = wethAddresses[network]
         aggregatorAddress = chainlinkAddresses[network]
         anchoredViewAddress = compoundAddresses[network]
-        ethUsdtPairAddress = ethUsdtAddresses[network]
         usdcEthPairAddress = usdcEthAddresses[network]
-        daiEthPairAddress = daiEthAddresses[network]
     }
 
     await deployer.deploy(
         USM,
         aggregatorAddress, anchoredViewAddress,
-        [ethUsdtPairAddress, usdcEthPairAddress, daiEthPairAddress],
-        uniswapTokens0Decimals, uniswapTokens1Decimals, uniswapTokensInReverseOrder
+        usdcEthPairAddress, usdcDecimals, ethDecimals, uniswapTokensInReverseOrder
     )
 }

--- a/test/01_TestOracle.test.js
+++ b/test/01_TestOracle.test.js
@@ -13,8 +13,10 @@ const GasCompoundOracle = artifacts.require('GasMeasuredCompoundOpenOracle')
 
 const UniswapV2Pair = artifacts.require('MockUniswapV2Pair')
 const GasUniswapSpotOracle = artifacts.require('GasMeasuredOurUniswapV2SpotOracle')
+const GasUniswapTWAPOracle = artifacts.require('GasMeasuredOurUniswapV2TWAPOracle')
 
 const GasUniswapMedianSpotOracle = artifacts.require('GasMeasuredUniswapMedianSpotOracle')
+const GasUniswapMedianTWAPOracle = artifacts.require('GasMeasuredUniswapMedianTWAPOracle')
 
 const GasMedianOracle = artifacts.require('GasMeasuredMedianOracle')
 
@@ -26,30 +28,62 @@ contract('Oracle pricing', (accounts) => {
   const makerPriceWAD = '392110000000000000000'             // Maker medianizer (IMakerPriceFeed) returns WAD 18-dec-place prices
 
   const chainlinkPrice = '38598000000'                      // Chainlink aggregator (AggregatorV3Interface) stores 8 dec places
-  const chainlinkPriceWAD = chainlinkPrice + '0000000000'   // We want 18 dec places, so add 10 0s
+  const chainlinkPriceWAD = new BN(chainlinkPrice + '0000000000') // We want 18 dec places, so add 10 0s
 
   const compoundPrice = '414174999'                         // Compound view (UniswapAnchoredView) stores 6 dec places
-  const compoundPriceWAD = compoundPrice + '000000000000'   // We want 18 dec places, so add 12 0s
+  const compoundPriceWAD = new BN(compoundPrice + '000000000000') // We want 18 dec places, so add 12 0s
 
   const ethDecimals = new BN(18)                            // See OurUniswapV2SpotOracle
   const usdtDecimals = new BN(6)
   const usdcDecimals = new BN(6)
   const daiDecimals = new BN(18)
+  const uniswapCumPriceScalingFactor = (new BN(2)).pow(new BN(112))
 
-  const ethUsdtReserve0 = '646310144553926227215994'        // From the ETH/USDT pair.  See OurUniswapV2SpotOracle
-  const ethUsdtReserve1 = '254384028636585'
+  const ethUsdtReserve0 = new BN('646310144553926227215994') // From the ETH/USDT pair.  See OurUniswapV2SpotOracle
+  const ethUsdtReserve1 = new BN('254384028636585')
+  const ethUsdtCumPrice0_0 = new BN('30197009659458262808281833965635')
+  const ethUsdtCumPrice1_0 = new BN('276776388531768266239160661937116320880685460468473')
+  const ethUsdtTimestamp_0 = new BN('1606780564')
+  const ethUsdtCumPrice0_1 = new BN('30198349396553956234684790868151')
+  const ethUsdtCumPrice1_1 = new BN('276779938284455484990752289414970402581013223198265')
+  const ethUsdtTimestamp_1 = new BN('1606780984')
   const ethUsdtTokensInReverseOrder = false
-  const ethUsdtScaleFactor = (new BN(10)).pow(new BN(30))   // This pair gives -12 dec places, we need 18.  See OurUniswapV2SpotOracle
+  const ethUsdtScaleFactor = (new BN(10)).pow(ethDecimals.add(new BN(18)).sub(usdtDecimals))
 
-  const usdcEthReserve0 = '260787673159143'
-  const usdcEthReserve1 = '696170744128378724814084'
+  const usdcEthReserve0 = new BN('260787673159143')         // From the USDC/ETH pair
+  const usdcEthReserve1 = new BN('696170744128378724814084')
+  const usdcEthCumPrice0_0 = new BN('307631784275278277546624451305316303382174855535226')
+  const usdcEthCumPrice1_0 = new BN('31377639132666967530700283664103')
+  const usdcEthTimestamp_0 = new BN('1606780664')
+  const usdcEthCumPrice0_1 = new BN('307634635050611880719301156089846577363471806696356')
+  const usdcEthCumPrice1_1 = new BN('31378725947216452626380862836246')
+  const usdcEthTimestamp_1 = new BN('1606781003')
   const usdcEthTokensInReverseOrder = true
-  const usdcEthScaleFactor = (new BN(10)).pow(new BN(30))   // This pair gives -12 dec places, we need 18
+  const usdcEthScaleFactor = (new BN(10)).pow(ethDecimals.add(new BN(18)).sub(usdcDecimals))
 
-  const daiEthReserve0 = '178617913077721329213551886'
-  const daiEthReserve1 = '480578265664207487333589'
+  const daiEthReserve0 = new BN('178617913077721329213551886') // From the DAI/ETH pair
+  const daiEthReserve1 = new BN('480578265664207487333589')
+  const daiEthCumPrice0_0 = new BN('291033362911607134656453476145906896216')
+  const daiEthCumPrice1_0 = new BN('30339833685805974401597062880404438583745289')
+  const daiEthTimestamp_0 = new BN('1606780728')
+  const daiEthCumPrice0_1 = new BN('291036072023637413832938851532265880018')
+  const daiEthCumPrice1_1 = new BN('30340852730044753766501469633003499944051151')
+  const daiEthTimestamp_1 = new BN('1606781048')
   const daiEthTokensInReverseOrder = true
-  const daiEthScaleFactor = (new BN(10)).pow(new BN(18))    // This pair gives 0 dec places, we need 18
+  const daiEthScaleFactor = (new BN(10)).pow(ethDecimals.add(new BN(18)).sub(daiDecimals))
+
+  function median(a, b, c) {
+    const ab = a > b
+    const bc = b > c
+    const ca = c > a
+    return (ca == ab ? a : (ab == bc ? b : c))
+  }
+
+  function shouldEqualApprox(x, y) {
+    // Check that abs(x - y) < 0.0000001(x + y):
+    const diff = (x.gt(y) ? x.sub(y) : y.sub(x))
+    diff.should.be.bignumber.lt(x.add(y).div(new BN(1000000)))
+  }
 
   describe("with TestOracle", () => {
     const [deployer] = accounts
@@ -105,7 +139,7 @@ contract('Oracle pricing', (accounts) => {
 
     it('returns the correct price', async () => {
       const oraclePrice = (await oracle.latestPrice())
-      oraclePrice.toString().should.equal(chainlinkPriceWAD)
+      oraclePrice.toString().should.equal(chainlinkPriceWAD.toString())
     })
 
     it('returns the price in a transaction', async () => {
@@ -127,7 +161,7 @@ contract('Oracle pricing', (accounts) => {
 
     it('returns the correct price', async () => {
       const oraclePrice = (await oracle.latestPrice())
-      oraclePrice.toString().should.equal(compoundPriceWAD)
+      oraclePrice.toString().should.equal(compoundPriceWAD.toString())
     })
 
     it('returns the price in a transaction', async () => {
@@ -142,7 +176,7 @@ contract('Oracle pricing', (accounts) => {
 
     beforeEach(async () => {
       pair = await UniswapV2Pair.new({ from: deployer })
-      await pair.set(ethUsdtReserve0, ethUsdtReserve1)
+      await pair.setReserves(ethUsdtReserve0, ethUsdtReserve1, 0)
 
       oracle = await GasUniswapSpotOracle.new(pair.address, ethDecimals, usdtDecimals, ethUsdtTokensInReverseOrder,
                                               { from: deployer })
@@ -150,8 +184,41 @@ contract('Oracle pricing', (accounts) => {
 
     it('returns the correct price', async () => {
       const oraclePrice = (await oracle.latestPrice())
-      const targetPrice = (new BN(ethUsdtReserve1)).mul(ethUsdtScaleFactor).div(new BN(ethUsdtReserve0)) // reverseOrder = false
+      const targetPrice = ethUsdtReserve1.mul(ethUsdtScaleFactor).div(ethUsdtReserve0) // reverseOrder = false
       oraclePrice.toString().should.equal(targetPrice.toString())
+    })
+
+    it('returns the price in a transaction', async () => {
+      const oraclePrice = (await oracle.latestPriceWithGas())
+    })
+  })
+
+  describe("with OurUniswapV2TWAPOracle", () => {
+    const [deployer] = accounts
+    let oracle
+    let pair
+
+    beforeEach(async () => {
+      pair = await UniswapV2Pair.new({ from: deployer })
+      await pair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_0)
+      await pair.setCumulativePrices(ethUsdtCumPrice0_0, ethUsdtCumPrice1_0)
+
+      oracle = await GasUniswapTWAPOracle.new(pair.address, ethDecimals, usdtDecimals, ethUsdtTokensInReverseOrder,
+                                              { from: deployer })
+      await oracle.cacheLatestPrice()
+
+      await pair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_1)
+      await pair.setCumulativePrices(ethUsdtCumPrice0_1, ethUsdtCumPrice1_1)
+      //await oracle.cacheLatestPrice() // Not actually needed, unless we do further testing moving timestamps further forward
+    })
+
+    it('returns the correct price', async () => {
+      const oraclePrice1 = (await oracle.latestPrice())
+
+      const targetOraclePriceNum = (ethUsdtCumPrice0_1.sub(ethUsdtCumPrice0_0)).mul(ethUsdtScaleFactor)
+      const targetOraclePriceDenom = (ethUsdtTimestamp_1.sub(ethUsdtTimestamp_0)).mul(uniswapCumPriceScalingFactor)
+      const targetOraclePrice1 = targetOraclePriceNum.div(targetOraclePriceDenom)
+      oraclePrice1.toString().should.equal(targetOraclePrice1.toString())
     })
 
     it('returns the price in a transaction', async () => {
@@ -166,13 +233,13 @@ contract('Oracle pricing', (accounts) => {
 
     beforeEach(async () => {
       ethUsdtPair = await UniswapV2Pair.new({ from: deployer })
-      await ethUsdtPair.set(ethUsdtReserve0, ethUsdtReserve1)
+      await ethUsdtPair.setReserves(ethUsdtReserve0, ethUsdtReserve1, 0)
 
       usdcEthPair = await UniswapV2Pair.new({ from: deployer })
-      await usdcEthPair.set(usdcEthReserve0, usdcEthReserve1)
+      await usdcEthPair.setReserves(usdcEthReserve0, usdcEthReserve1, 0)
 
       daiEthPair = await UniswapV2Pair.new({ from: deployer })
-      await daiEthPair.set(daiEthReserve0, daiEthReserve1)
+      await daiEthPair.setReserves(daiEthReserve0, daiEthReserve1, 0)
 
       oracle = await GasUniswapMedianSpotOracle.new(
           [ethUsdtPair.address, usdcEthPair.address, daiEthPair.address],
@@ -183,9 +250,72 @@ contract('Oracle pricing', (accounts) => {
 
     it('returns the correct price', async () => {
       const oraclePrice = (await oracle.latestPrice())
-      // Of the three pairs, the USDC/ETH pair has the middle price, so UniswapMedianOracle's price should match it:
-      const targetPrice = (new BN(usdcEthReserve0)).mul(usdcEthScaleFactor).div(new BN(usdcEthReserve1)) // reverseOrder = true
+      // Of the three pairs, the USDC/ETH pair has the middle price, so UniswapMedianSpotOracle's price should match it:
+      const targetPrice = usdcEthReserve0.mul(usdcEthScaleFactor).div(usdcEthReserve1) // reverseOrder = true
       oraclePrice.toString().should.equal(targetPrice.toString())
+    })
+
+    it('returns the price in a transaction', async () => {
+      const oraclePrice = (await oracle.latestPriceWithGas())
+    })
+  })
+
+  describe("with UniswapMedianTWAPOracle", () => {
+    const [deployer] = accounts
+    let oracle
+    let ethUsdtPair, usdcEthPair, daiEthPair
+
+    beforeEach(async () => {
+      ethUsdtPair = await UniswapV2Pair.new({ from: deployer })
+      await ethUsdtPair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_0)
+      await ethUsdtPair.setCumulativePrices(ethUsdtCumPrice0_0, ethUsdtCumPrice1_0)
+
+      usdcEthPair = await UniswapV2Pair.new({ from: deployer })
+      await usdcEthPair.setReserves(usdcEthReserve0, usdcEthReserve1, usdcEthTimestamp_0)
+      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_0, usdcEthCumPrice1_0)
+
+      daiEthPair = await UniswapV2Pair.new({ from: deployer })
+      await daiEthPair.setReserves(daiEthReserve0, daiEthReserve1, daiEthTimestamp_0)
+      await daiEthPair.setCumulativePrices(daiEthCumPrice0_0, daiEthCumPrice1_0)
+
+      oracle = await GasUniswapMedianTWAPOracle.new(
+          [ethUsdtPair.address, usdcEthPair.address, daiEthPair.address],
+          [ethDecimals, usdcDecimals, daiDecimals],
+          [usdtDecimals, ethDecimals, ethDecimals],
+          [ethUsdtTokensInReverseOrder, usdcEthTokensInReverseOrder, daiEthTokensInReverseOrder], { from: deployer })
+      await oracle.cacheLatestPrice()
+
+      await ethUsdtPair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_1)
+      await ethUsdtPair.setCumulativePrices(ethUsdtCumPrice0_1, ethUsdtCumPrice1_1)
+      await usdcEthPair.setReserves(usdcEthReserve0, usdcEthReserve1, usdcEthTimestamp_1)
+      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_1, usdcEthCumPrice1_1)
+      await daiEthPair.setReserves(daiEthReserve0, daiEthReserve1, daiEthTimestamp_1)
+      await daiEthPair.setCumulativePrices(daiEthCumPrice0_1, daiEthCumPrice1_1)
+      //await oracle.cacheLatestPrice() // Not actually needed, unless we do further testing moving timestamps further forward
+    })
+
+    it('returns the correct price', async () => {
+      const ethUsdtPrice1 = (await oracle.latestUniswapPair1TWAPPrice())
+      const targetEthUsdtPriceNum = (ethUsdtCumPrice0_1.sub(ethUsdtCumPrice0_0)).mul(ethUsdtScaleFactor)
+      const targetEthUsdtPriceDenom = (ethUsdtTimestamp_1.sub(ethUsdtTimestamp_0)).mul(uniswapCumPriceScalingFactor)
+      const targetEthUsdtPrice1 = targetEthUsdtPriceNum.div(targetEthUsdtPriceDenom)
+      shouldEqualApprox(ethUsdtPrice1, targetEthUsdtPrice1)
+
+      const usdcEthPrice1 = (await oracle.latestUniswapPair2TWAPPrice())
+      const targetUsdcEthPriceNum = (usdcEthCumPrice1_1.sub(usdcEthCumPrice1_0)).mul(usdcEthScaleFactor)
+      const targetUsdcEthPriceDenom = (usdcEthTimestamp_1.sub(usdcEthTimestamp_0)).mul(uniswapCumPriceScalingFactor)
+      const targetUsdcEthPrice1 = targetUsdcEthPriceNum.div(targetUsdcEthPriceDenom)
+      shouldEqualApprox(usdcEthPrice1, targetUsdcEthPrice1)
+
+      const daiEthPrice1 = (await oracle.latestUniswapPair3TWAPPrice())
+      const targetDaiEthPriceNum = (daiEthCumPrice1_1.sub(daiEthCumPrice1_0)).mul(daiEthScaleFactor)
+      const targetDaiEthPriceDenom = (daiEthTimestamp_1.sub(daiEthTimestamp_0)).mul(uniswapCumPriceScalingFactor)
+      const targetDaiEthPrice1 = targetDaiEthPriceNum.div(targetDaiEthPriceDenom)
+      shouldEqualApprox(daiEthPrice1, targetDaiEthPrice1)
+
+      const oraclePrice1 = (await oracle.latestPrice())
+      const targetOraclePrice1 = median(ethUsdtPrice1, usdcEthPrice1, daiEthPrice1)
+      oraclePrice1.toString().should.equal(targetOraclePrice1.toString())
     })
 
     it('returns the price in a transaction', async () => {
@@ -209,25 +339,38 @@ contract('Oracle pricing', (accounts) => {
       await compoundView.set(compoundPrice)
 
       ethUsdtPair = await UniswapV2Pair.new({ from: deployer })
-      await ethUsdtPair.set(ethUsdtReserve0, ethUsdtReserve1)
+      await ethUsdtPair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_0)
+      await ethUsdtPair.setCumulativePrices(ethUsdtCumPrice0_0, ethUsdtCumPrice1_0)
 
       usdcEthPair = await UniswapV2Pair.new({ from: deployer })
-      await usdcEthPair.set(usdcEthReserve0, usdcEthReserve1)
+      await usdcEthPair.setReserves(usdcEthReserve0, usdcEthReserve1, usdcEthTimestamp_0)
+      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_0, usdcEthCumPrice1_0)
 
       daiEthPair = await UniswapV2Pair.new({ from: deployer })
-      await daiEthPair.set(daiEthReserve0, daiEthReserve1)
+      await daiEthPair.setReserves(daiEthReserve0, daiEthReserve1, daiEthTimestamp_0)
+      await daiEthPair.setCumulativePrices(daiEthCumPrice0_0, daiEthCumPrice1_0)
 
       oracle = await GasMedianOracle.new(chainlinkAggregator.address, compoundView.address,
         [ethUsdtPair.address, usdcEthPair.address, daiEthPair.address],
         [ethDecimals, usdcDecimals, daiDecimals],
         [usdtDecimals, ethDecimals, ethDecimals],
         [ethUsdtTokensInReverseOrder, usdcEthTokensInReverseOrder, daiEthTokensInReverseOrder], { from: deployer })
+      await oracle.cacheLatestPrice()
+
+      await ethUsdtPair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_1)
+      await ethUsdtPair.setCumulativePrices(ethUsdtCumPrice0_1, ethUsdtCumPrice1_1)
+      await usdcEthPair.setReserves(usdcEthReserve0, usdcEthReserve1, usdcEthTimestamp_1)
+      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_1, usdcEthCumPrice1_1)
+      await daiEthPair.setReserves(daiEthReserve0, daiEthReserve1, daiEthTimestamp_1)
+      await daiEthPair.setCumulativePrices(daiEthCumPrice0_1, daiEthCumPrice1_1)
+      //await oracle.cacheLatestPrice() // Not actually needed, unless we do further testing moving timestamps further forward
     })
 
     it('returns the correct price', async () => {
       const oraclePrice = (await oracle.latestPrice())
-      // Of the three oracles (Chainlink, Compound, UniswapMedian), Chainlink's is in the middle, so MedianOracle should match it:
-      oraclePrice.toString().should.equal(chainlinkPriceWAD)
+      const uniswapMedianPrice = (await oracle.latestUniswapMedianTWAPPrice())
+      const targetOraclePrice = median(chainlinkPriceWAD, compoundPriceWAD, uniswapMedianPrice)
+      oraclePrice.toString().should.equal(targetOraclePrice.toString())
     })
 
     it('returns the price in a transaction', async () => {

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -43,17 +43,32 @@ contract('USM', (accounts) => {
   const uniswapTokens1Decimals = [SIX, EIGHTEEN, EIGHTEEN]  // See UniswapMedianSpotOracle
   const uniswapTokensInReverseOrder = [false, true, true]   // See UniswapMedianSpotOracle
 
-  const ethUsdtReserve0 = '646310144553926227215994'
-  const ethUsdtReserve1 = '254384028636585'
-  const ethUsdtPrice = '393594361437970499059'              // = ethUsdtReserve1 * ethUsdtScaleFactor / ethUsdtReserve0
+  const ethUsdtReserve0 = new BN('646310144553926227215994') // From the ETH/USDT pair.  See OurUniswapV2SpotOracle
+  const ethUsdtReserve1 = new BN('254384028636585')
+  const ethUsdtCumPrice0_0 = new BN('30197009659458262808281833965635')
+  const ethUsdtCumPrice1_0 = new BN('276776388531768266239160661937116320880685460468473')
+  const ethUsdtTimestamp_0 = new BN('1606780564')
+  const ethUsdtCumPrice0_1 = new BN('30198349396553956234684790868151')
+  const ethUsdtCumPrice1_1 = new BN('276779938284455484990752289414970402581013223198265')
+  const ethUsdtTimestamp_1 = new BN('1606780984')
 
-  const usdcEthReserve0 = '260787673159143'
-  const usdcEthReserve1 = '696170744128378724814084'
-  const usdcEthPrice = '374603034325515896918'              // = usdcEthReserve0 * usdcEthScaleFactor / usdcEthReserve1
+  const usdcEthReserve0 = new BN('260787673159143')         // From the USDC/ETH pair
+  const usdcEthReserve1 = new BN('696170744128378724814084')
+  const usdcEthCumPrice0_0 = new BN('307631784275278277546624451305316303382174855535226')
+  const usdcEthCumPrice1_0 = new BN('31377639132666967530700283664103')
+  const usdcEthTimestamp_0 = new BN('1606780664')
+  const usdcEthCumPrice0_1 = new BN('307634635050611880719301156089846577363471806696356')
+  const usdcEthCumPrice1_1 = new BN('31378725947216452626380862836246')
+  const usdcEthTimestamp_1 = new BN('1606781003')
 
-  const daiEthReserve0 = '178617913077721329213551886'
-  const daiEthReserve1 = '480578265664207487333589'
-  const daiEthPrice = '371672890430975717452'               // = daiEthReserve0 * daiEthScaleFactor / daiEthReserve1
+  const daiEthReserve0 = new BN('178617913077721329213551886') // From the DAI/ETH pair
+  const daiEthReserve1 = new BN('480578265664207487333589')
+  const daiEthCumPrice0_0 = new BN('291033362911607134656453476145906896216')
+  const daiEthCumPrice1_0 = new BN('30339833685805974401597062880404438583745289')
+  const daiEthTimestamp_0 = new BN('1606780728')
+  const daiEthCumPrice0_1 = new BN('291036072023637413832938851532265880018')
+  const daiEthCumPrice1_1 = new BN('30340852730044753766501469633003499944051151')
+  const daiEthTimestamp_1 = new BN('1606781048')
 
   function wadMul(x, y, upOrDown) {
     return ((x.mul(y)).add(upOrDown == rounds.DOWN ? ZERO : WAD_MINUS_1)).div(WAD)
@@ -121,13 +136,16 @@ contract('USM', (accounts) => {
       await anchoredView.set(compoundPrice)
 
       ethUsdtPair = await UniswapV2Pair.new({ from: deployer })
-      await ethUsdtPair.set(ethUsdtReserve0, ethUsdtReserve1)
+      await ethUsdtPair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_0)
+      await ethUsdtPair.setCumulativePrices(ethUsdtCumPrice0_0, ethUsdtCumPrice1_0)
 
       usdcEthPair = await UniswapV2Pair.new({ from: deployer })
-      await usdcEthPair.set(usdcEthReserve0, usdcEthReserve1)
+      await usdcEthPair.setReserves(usdcEthReserve0, usdcEthReserve1, usdcEthTimestamp_0)
+      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_0, usdcEthCumPrice1_0)
 
       daiEthPair = await UniswapV2Pair.new({ from: deployer })
-      await daiEthPair.set(daiEthReserve0, daiEthReserve1)
+      await daiEthPair.setReserves(daiEthReserve0, daiEthReserve1, daiEthTimestamp_0)
+      await daiEthPair.setCumulativePrices(daiEthCumPrice0_0, daiEthCumPrice1_0)
 
       // USM
       usm = await USM.new(aggregator.address, anchoredView.address,
@@ -135,6 +153,14 @@ contract('USM', (accounts) => {
                           uniswapTokens0Decimals, uniswapTokens1Decimals, uniswapTokensInReverseOrder,
                           { from: deployer })
       fum = await FUM.at(await usm.fum())
+      await usm.cacheLatestPrice()
+
+      await ethUsdtPair.setReserves(ethUsdtReserve0, ethUsdtReserve1, ethUsdtTimestamp_1)
+      await ethUsdtPair.setCumulativePrices(ethUsdtCumPrice0_1, ethUsdtCumPrice1_1)
+      await usdcEthPair.setReserves(usdcEthReserve0, usdcEthReserve1, usdcEthTimestamp_1)
+      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_1, usdcEthCumPrice1_1)
+      await daiEthPair.setReserves(daiEthReserve0, daiEthReserve1, daiEthTimestamp_1)
+      await daiEthPair.setCumulativePrices(daiEthCumPrice0_1, daiEthCumPrice1_1)
 
       priceWAD = await usm.latestPrice()
       oneDollarInEth = wadDiv(WAD, priceWAD, rounds.UP)


### PR DESCRIPTION
This definitely needs some eyeballs on it...  The key files are:
- `OurUniswapV2TWAPOracle`, which implements TWAP for a single Uniswap pair.  `MIN_TWAP_PERIOD` is currently set (a bit arbitrarily) to 2 minutes - see the long comment at the top.  `USM` doesn't actually use this file, but it's an easier-to-read-and-debug little brother of...
- `UniswapMedianTWAPOracle`, which mirrors the TWAP-storing-and-calculating logic in `OurUniswapV2TWAPOracle` but for _three_ Uniswap pairs, then taking their median (as we currently do in `UniswapMedianSpotOracle`).  In particular, the logic for storing three pairs' cumulative prices (plus timestamps) in one 256-bit word could use review...
- `MedianOracle` used to take `UniswapMedianSpotOracle` as one of its three sources to median (along with Chainlink and Compound): now I swapped in `UniswapMedianTWAPOracle` instead.  `USM` inherits `latestPrice()` from `MedianOracle`, so changing how `MedianOracle` works implicitly changes `USM` too.
- `OurUniswap` has the actual TWAP logic - that math itself isn't too messy.
- And I updated tests 01 and 03 to do some minimal checks of the TWAP logic.  In particular, to make it call `cacheLatestPrice()`, the function that records a TWAP observation so that later `latestPrice()` calls have a stored reference to price against.

The tests do pass (and I did some basic sanity-checking via logging), and I've tried to keep the code reasonably clean.  Currently `mint` is at 163k gas vs 100k in master but I expect we can get that down, I haven't tried at all yet.