### PR TITLE
fundWithUsm()

### DIFF
--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -35,7 +35,7 @@ contract FUM is ERC20Permit, Ownable {
      */
     function _transfer(address sender, address recipient, uint256 amount) internal override {
         if (recipient == address(this) || recipient == address(usm) || recipient == address(0)) {
-            usm.defundFromFUM(sender, payable(sender), amount, MinOut.parseMinEthOut(amount));
+            usm.defundFromFum(sender, payable(sender), amount, MinOut.parseMinEthOut(amount));
         } else {
             super._transfer(sender, recipient, amount);
         }

--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -6,5 +6,5 @@ interface IUSM {
     function burn(address from, address payable to, uint usmToBurn, uint minEthOut) external returns (uint);
     function fund(address to, uint minFumOut) external payable returns (uint);
     function defund(address from, address payable to, uint fumToBurn, uint minEthOut) external returns (uint);
-    function defundFromFUM(address from, address payable to, uint fumToBurn, uint minEthOut) external returns (uint);
+    function defundFromFum(address from, address payable to, uint fumToBurn, uint minEthOut) external returns (uint);
 }

--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -5,6 +5,7 @@ interface IUSM {
     function mint(address to, uint minUsmOut) external payable returns (uint);
     function burn(address from, address payable to, uint usmToBurn, uint minEthOut) external returns (uint);
     function fund(address to, uint minFumOut) external payable returns (uint);
+    function fundWithUsm(address from, address to, uint usmToBurn, uint minFumOut) external returns (uint);
     function defund(address from, address payable to, uint fumToBurn, uint minEthOut) external returns (uint);
     function defundFromFum(address from, address payable to, uint fumToBurn, uint minEthOut) external returns (uint);
 }


### PR DESCRIPTION
`fundWithUsm(usm)` is (should be) exactly equivalent in effect to `fund(burn(usm))`, but it may still be worth adding because:
1. It saves gas: 120k for `fundWithUsm()`, vs 178k total for `burn()` followed by `fund()`.
2. Unlike `fund(burn())`, there's no risk of the `burn()` getting rejected because debt ratio > 100%.

These would both help incentivize calls to it, which is good: it's always a net-positive-for-funding (debt-ratio-reducing) operation, and we want to incentivize those.

That said, we don't _really_ need this.

(In case you're wondering, I don't see much case for adding the 6th and final operation, `defundForUsm()`.  Let them pay up for the `defund()` followed by the `mint()` - we have no reason to incentive that!)