### PR TITLE
Fix/mint math

### DIFF
--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -22,7 +22,7 @@ contract FUM is ERC20Permit, Ownable {
     /**
      * @notice If anyone sends ETH here, assume they intend it as a `fund`.
      * If decimals 8 to 11 (included) of the amount of Ether received are `0000` then the next 7 will
-     * be parsed as the minimum Ether price accepted, with 2 digits before and 5 digits after the comma. 
+     * be parsed as the minimum Ether price accepted, with 2 digits before and 5 digits after the comma.
      */
     receive() external payable {
         usm.fund{ value: msg.value }(msg.sender, MinOut.parseMinTokenOut(msg.value));

--- a/deploy/1_deploy_usmfum.js
+++ b/deploy/1_deploy_usmfum.js
@@ -36,7 +36,7 @@ const func = async function ({ deployments, getNamedAccounts, getChainId }) {
     const compoundPrice = '414174999' // 6 dec places: see CompoundOpenOracle
     const usdcEthCumPrice0 = '307631784275278277546624451305316303382174855535226'
     const usdcEthCumPrice1 = '31377639132666967530700283664103'
-    
+
     aggregator = await deploy('MockChainlinkAggregatorV3', {
       from: deployer,
       deterministicDeployment: true,


### PR DESCRIPTION
This is the bug I noticed in kovan testing where, when debt ratio > 100%, `mint(0.01 ETH)` @ price = $100 was incorrectly returning > 1 USM...  (Sliding prices should _always_ make it return <= 1 USM.)  I think this fixes it but it's obviously pretty hot off the presses...