### PR TITLE
feat: implemented caps

### DIFF
--- a/contracts/USMTemplate.sol
+++ b/contracts/USMTemplate.sol
@@ -164,6 +164,9 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
         uint newDebtRatio = debtRatio(ethUsmPrice, rawEthInPool, usmTotalSupply.add(usmOut));
         _updateBuySellAdjustment(oldDebtRatio, newDebtRatio, buySellAdjustment());
         _mint(to, usmOut);
+
+        require(ethPool() <= 1e20, "Capped at 100 pooled ETH");
+        require(balanceOf(to) <= 1e21, "Capped at 1000 USM per address");
     }
 
     function _burnUsm(address from, address payable to, uint usmToBurn, uint minEthOut) internal returns (uint ethOut)
@@ -204,6 +207,9 @@ abstract contract USMTemplate is IUSM, Oracle, ERC20Permit, Delegable {
         uint newDebtRatio = debtRatio(ethUsmPrice, rawEthInPool, usmTotalSupply);
         _updateBuySellAdjustment(oldDebtRatio, newDebtRatio, adjustment);
         fum.mint(to, fumOut);
+
+        require(ethPool() <= 1e20, "Capped at 100 pooled ETH");
+        require(fum.balanceOf(to) <= 1e21, "Capped at 1000 FUM per address");
     }
 
     function _defundFum(address from, address payable to, uint fumToBurn, uint minEthOut) internal returns (uint ethOut)

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -132,8 +132,8 @@ contract('USM', (accounts) => {
       priceWAD = await usm.latestPrice()
       oneDollarInEth = wadDiv(WAD, priceWAD, rounds.UP)
 
-      ethPerFund = oneEth.mul(TWO)                  // Can be any (?) number
-      ethPerMint = oneEth.mul(FOUR)                 // Can be any (?) number
+      ethPerFund = oneEth.div(TWO) // .mul(TWO)                  // Can be any (?) number
+      ethPerMint = oneEth          // .mul(FOUR)                 // Can be any (?) number
       bitOfEth = oneEth.div(THOUSAND)
 
       snapshot = await timeMachine.takeSnapshot()
@@ -224,6 +224,16 @@ contract('USM', (accounts) => {
         shouldEqualApprox(fumSellPrice1, oneDollarInEth)
       })
 
+      it("Capped at 1000 FUM per address", async () => {
+        const thousandWAD = WAD.mul(new BN('1000'))
+        let targetEthIn = wadDiv(thousandWAD, priceWAD, rounds.UP)
+        await usm.fund(user2, 0, { value: targetEthIn , from: user2 });
+
+        await expectRevert(
+          usm.fund(user2, 0, { value: wadDiv(WAD, priceWAD, rounds.UP) , from: user2 }),
+          "Capped at 1000 FUM per address"
+        )
+      })
 
       describe("with existing FUM supply", () => {
         let ethPool1, user2FumBalance1, totalFumSupply1, buySellAdj1, fumBuyPrice1, fumSellPrice1
@@ -297,6 +307,17 @@ contract('USM', (accounts) => {
           shouldEqualApprox(fumBuyPrice2, oneDollarInEth)
           shouldEqualApprox(fumSellPrice2, oneDollarInEth)
         })
+
+        it("Capped at 1000 USM per address", async () => {
+          const thousandWAD = WAD.mul(new BN('1000'))
+          let targetEthIn = wadDiv(thousandWAD, priceWAD, rounds.UP)
+          await usm.mint(user2, 0, { value: targetEthIn , from: user2 });
+  
+          await expectRevert(
+            usm.mint(user2, 0, { value: wadDiv(WAD, priceWAD, rounds.UP) , from: user2 }),
+            "Capped at 1000 USM per address"
+          )
+        })  
 
         describe("with existing USM supply", () => {
           let ethPool2, debtRatio2, user1UsmBalance2, totalUsmSupply2, buySellAdj2, fumBuyPrice2, fumSellPrice2, usmBuyPrice2,


### PR DESCRIPTION
Max of 1000 FUM and USM per address. Max of 100 ETH pooled between all users.

Someone can sybil attack and use 50 addresses or so to use up all the liquidity, but it would be a bit pointless.