### PR TITLE
WIP: Zero-fee Optional Upgrade

### DIFF
--- a/contracts/UpgradableUSM.sol
+++ b/contracts/UpgradableUSM.sol
@@ -50,13 +50,18 @@ contract UpgradableUSM is USM, Ownable {
      * @param ethAmount uint amount of ETH collateral to send with swap
      * @return success - This determines whether or not the upgrade contract mints new tokens to the holder
      */
-    function requestSwap(address holder, uint ethAmount) external onlyUpgradeAddress returns (bool){
+    function requestSwap(address holder, uint ethAmount) external upgrading onlyUpgradeAddress returns (bool){
         require(address(this).balance >= ethAmount, "Not enough ether");
         uint tokenBalance = balanceOf(holder);
         require(tokenBalance > 0, "Holder has no tokens to swap");
         _burn(holder, tokenBalance);
         payable(upgradeAddress).sendValue(ethAmount);
         return true;
+    }
+
+    modifier upgrading() {
+        require(upgradeAddress != address(0), "Not currently upgrading");
+        _;
     }
 
     modifier upgradeAddressNotSet() {

--- a/contracts/UpgradableUSM.sol
+++ b/contracts/UpgradableUSM.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.6;
+
+import "./USM.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "./oracles/Oracle.sol";
+
+contract UpgradableUSM is USM, Ownable {
+    using Address for address;
+    using Address for address payable;
+
+    address public upgradeAddress;
+    address public proposedUpgradeAddress;
+
+    event UpgradeAddressProposed(address indexed previousProposal, address indexed newProposal);
+    event UpgradeAddressConfirmed(address indexed upgradeAddress);
+
+    constructor(Oracle oracle_) public USM(oracle_) {}
+
+    /**
+     * @notice Propose an upgrade address.
+     * @dev Must be a contract address, callable only by owner and callable only if the
+     * upgradeAddress is not already set 
+     * @param proposed address
+     */
+    function proposeUpgradeAddress(address proposed) external onlyOwner upgradeAddressNotSet {
+        require(proposed.isContract(), "Must be contract");
+        address priorProposal = proposedUpgradeAddress;
+        proposedUpgradeAddress = proposed;
+        emit UpgradeAddressProposed(priorProposal, proposed);
+    }
+
+    /**
+     * @notice Confirm the currently proposedUpgradeAddress as the upgradeAddress/
+     * @dev THIS CAN ONLY BE DONE ONCE. Only callable by owner and upgradeAddress must not already
+     * be set.
+     * @param confirmed address to confirm
+     */
+    function confirmUpgradeAddress(address confirmed) external onlyOwner upgradeAddressNotSet {
+        require(proposedUpgradeAddress == confirmed, "Does not match proposed");
+        upgradeAddress = proposedUpgradeAddress;
+        emit UpgradeAddressConfirmed(upgradeAddress);
+    }
+
+    /**
+     * @notice Request to swap all old tokens owned by the holder to new upgrade tokens
+     * @dev This must be called by the upgrade address
+     * @param holder address
+     * @param ethAmount uint amount of ETH collateral to send with swap
+     * @return success - This determines whether or not the upgrade contract mints new tokens to the holder
+     */
+    function requestSwap(address holder, uint ethAmount) external onlyUpgradeAddress returns (bool){
+        require(address(this).balance >= ethAmount, "Not enough ether");
+        uint tokenBalance = balanceOf(holder);
+        require(tokenBalance > 0, "Holder has no tokens to swap");
+        _burn(holder, tokenBalance);
+        payable(upgradeAddress).sendValue(ethAmount);
+        return true;
+    }
+
+    modifier upgradeAddressNotSet() {
+        require(upgradeAddress == address(0), "Upgrade address already set");
+        _;
+    }
+
+    modifier onlyUpgradeAddress() {
+        require(msg.sender == upgradeAddress, "Must be upgrade address");
+        _;
+    }
+}

--- a/contracts/UpgradableUSM.sol
+++ b/contracts/UpgradableUSM.sol
@@ -47,12 +47,13 @@ contract UpgradableUSM is USM, Ownable {
      * @notice Request to swap all old tokens owned by the holder to new upgrade tokens
      * @dev This must be called by the upgrade address
      * @param holder address
-     * @param ethAmount uint amount of ETH collateral to send with swap
      * @return success - This determines whether or not the upgrade contract mints new tokens to the holder
      */
-    function requestSwap(address holder, uint ethAmount) external upgrading onlyUpgradeAddress returns (bool){
-        require(address(this).balance >= ethAmount, "Not enough ether");
+    function requestSwap(address holder) external upgrading onlyUpgradeAddress returns (bool){
+        (uint price,,,) = _refreshPrice();
         uint tokenBalance = balanceOf(holder);
+        uint ethAmount = tokenBalance.wadDivDown(price);
+        require(address(this).balance >= ethAmount, "Not enough ether");
         require(tokenBalance > 0, "Holder has no tokens to swap");
         _burn(holder, tokenBalance);
         payable(upgradeAddress).sendValue(ethAmount);

--- a/contracts/UpgradableUSM.sol
+++ b/contracts/UpgradableUSM.sol
@@ -50,11 +50,11 @@ contract UpgradableUSM is USM, Ownable {
      * @return success - This determines whether or not the upgrade contract mints new tokens to the holder
      */
     function requestSwap(address holder) external upgrading onlyUpgradeAddress returns (bool){
-        (uint price,,,) = _refreshPrice();
         uint tokenBalance = balanceOf(holder);
+        require(tokenBalance > 0, "Holder has no tokens to swap");
+        (uint price,,,) = _refreshPrice();
         uint ethAmount = tokenBalance.wadDivDown(price);
         require(address(this).balance >= ethAmount, "Not enough ether");
-        require(tokenBalance > 0, "Holder has no tokens to swap");
         _burn(holder, tokenBalance);
         payable(upgradeAddress).sendValue(ethAmount);
         return true;


### PR DESCRIPTION
Fixes #25 .

In the event of the protocol acting unexpectedly, or to enable users to upgrade to a new version, proposal to add a zero-fee optional upgrade mechanism.

In the event of this happening, USM1 is the compromised/old contract, USM2 is the newly deployed upgrade contract.

Owner flow:
1. Deploy USM2 (with a `recover` function intended to start the USM1 holder user flow)
2. Propose USM2 address to USM1 by calling `proposeUpgradeAddress`
3. Confirm proposed address by calling `confirmUpgradeAddress`

User flow:
1. USM1 holder calls a `recover` (or some similar) function on USM2
2. USM2 calculates the amount of ETH collateral that USM1 should transfer to it along with the user's full USM1 balance, then calls `requestSwap(holder, ethAmount)` on USM1
3. `requestSwap` burns the tokens, transfers the ETH, and returns true if all is well
4. USM2 is responsible for minting USM2 tokens to the holder depending on the result of `requestSwap`