### PR TITLE
Major change, with 2 main components:

### DIFF
--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -12,16 +12,21 @@ abstract contract IUSM {
     function defund(address from, address payable to, uint fumToBurn, uint minEthOut) external virtual returns (uint);
     function defundFromFUM(address from, address payable to, uint fumToBurn, uint minEthOut) external virtual returns (uint);
 
+    function refreshPrice() public virtual returns (uint price, uint updateTime);
+
     function latestPrice() public virtual view returns (uint price, uint updateTime);
     function latestOraclePrice() public virtual view returns (uint price, uint updateTime);
     function ethPool() public virtual view returns (uint pool);
     function usmTotalSupply() public virtual view returns (uint supply);    // Is there a way to scrap this and just use ERC20(Permit)'s totalSupply()?
     function fumTotalSupply() public virtual view returns (uint supply);
     function buySellAdjustment() public virtual view returns (uint adjustment);
+    function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater) public virtual view returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys);
+    function timeSystemWentUnderwater() public virtual view returns (uint timestamp);
+
     function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, WadMath.Round upOrDown) public virtual pure returns (int buffer);
     function debtRatio(uint ethUsdPrice, uint ethInPool, uint usmSupply) public virtual pure returns (uint ratio);
     function ethToUsm(uint ethUsdPrice, uint ethAmount, WadMath.Round upOrDown) public virtual pure returns (uint usmOut);
     function usmToEth(uint ethUsdPrice, uint usmAmount, WadMath.Round upOrDown) public virtual pure returns (uint ethOut);
-    function usmPrice(Side side, uint ethUsdPrice, uint debtRatio_) public virtual view returns (uint price);
-    function fumPrice(Side side, uint ethUsdPrice, uint ethInPool, uint usmSupply, uint fumSupply, uint adjustment) public virtual view returns (uint price);
+    function usmPrice(Side side, uint ethUsdPrice, uint debtRatio_) public virtual pure returns (uint price);
+    function fumPrice(Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply, uint adjustment) public virtual pure returns (uint price);
 }

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -29,12 +29,14 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
     using Address for address payable;
     using WadMath for uint;
 
-    event MinFumBuyPriceChanged(uint previous, uint latest);
+    event UnderwaterStatusChanged(bool previous, bool latest);
     event BuySellAdjustmentChanged(uint previous, uint latest);
     event PriceChanged(uint previous, uint latest);
 
     uint public constant WAD = 10 ** 18;
     uint public constant HALF_WAD = WAD / 2;
+    uint public constant BILLION = 10 ** 9;
+    uint public constant HALF_BILLION = BILLION / 2;
     uint public constant MAX_DEBT_RATIO = WAD * 8 / 10;                 // 80%
     uint public constant MIN_FUM_BUY_PRICE_HALF_LIFE = 1 days;          // Solidity for 1 * 24 * 60 * 60
     uint public constant BUY_SELL_ADJUSTMENT_HALF_LIFE = 1 minutes;     // Solidity for 1 * 60
@@ -42,14 +44,28 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
     FUM public immutable fum;
     Oracle public immutable oracle;
 
-    struct TimedValue {
-        uint32 timestamp;
-        uint224 value;
+    struct StoredState {
+        uint32 timeSystemWentUnderwater;    // Time at which (we noticed) debt ratio went > MAX, or 0 if it's currently < MAX
+        uint32 ethUsdPriceTimestamp;
+        uint80 ethUsdPrice;                 // Stored in billionths, not WADs: so 123.456 is stored as 123,456,000,000
+        uint32 buySellAdjustmentTimestamp;
+        uint80 buySellAdjustment;           // Stored in billionths, not WADs
     }
 
-    TimedValue public storedPrice;
-    TimedValue public storedMinFumBuyPrice;
-    TimedValue public storedBuySellAdjustment = TimedValue({ timestamp: 0, value: uint224(WAD) });
+    struct LoadedState {
+        uint timeSystemWentUnderwater;
+        uint ethUsdPriceTimestamp;
+        uint ethUsdPrice;                   // This one is in WADs, not billionths
+        uint buySellAdjustmentTimestamp;
+        uint buySellAdjustment;             // WADs, not billionths
+        uint ethPool;
+        uint usmTotalSupply;
+    }
+
+    StoredState public storedState = StoredState({
+        timeSystemWentUnderwater: 0, ethUsdPriceTimestamp: 0, ethUsdPrice: 0,
+        buySellAdjustmentTimestamp: 0, buySellAdjustment: uint80(BILLION)       // initialize adjustment to 1.0 (scaled by 1b)
+    });
 
     constructor(Oracle oracle_, address[] memory optedOut_)
         ERC20WithOptOut("Minimal USD", "USM", optedOut_)
@@ -137,13 +153,13 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
 
     // ____________________ Public transactional functions ____________________
 
-    function refreshPrice() public virtual override returns (uint price, uint updateTime) {
-        uint adjustment;
+    function refreshPrice() public virtual override(IUSM, Oracle) returns (uint price, uint updateTime) {
+        LoadedState memory ls = loadState();
         bool priceChanged;
-        (price, updateTime, adjustment, priceChanged) = _refreshPrice();
+        (price, updateTime, ls.buySellAdjustment, priceChanged) = _refreshPrice(ls);
         if (priceChanged) {
-            _storeBuySellAdjustment(adjustment);
-            _storePrice(price, updateTime);
+            (ls.ethUsdPrice, ls.ethUsdPriceTimestamp) = (price, updateTime);
+            _storeState(ls);
         }
     }
 
@@ -167,86 +183,126 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
 
     function _mintUsm(address to, uint minUsmOut) internal returns (uint usmOut)
     {
-        // 1. Check that fund() has been called first - no minting before funding:
-        uint rawEthInPool = ethPool();
-        uint ethInPool = rawEthInPool - msg.value;   // Backing out the ETH just received, which our calculations should ignore
-        require(ethInPool > 0, "Fund before minting");
+        // 1. Load the stored state:
+        LoadedState memory ls = loadState();
+        ls.ethPool -= msg.value;    // Backing out the ETH just received, which our calculations should ignore
 
-        // 2. Calculate usmOut:
-        (uint ethUsdPrice0, uint priceUpdateTime, uint adjustment0, ) = _refreshPrice();
+        // 2. Check that fund() has been called first - no minting before funding:
+        require(ls.ethPool > 0, "Fund before minting");
+
+        // 3. Refresh the oracle price:
+        (ls.ethUsdPrice, ls.ethUsdPriceTimestamp, ls.buySellAdjustment, ) = _refreshPrice(ls);
+
+        // 4. Calculate usmOut:
         uint adjShrinkFactor;
-        (usmOut, adjShrinkFactor) = usmFromMint(ethUsdPrice0, msg.value, ethInPool, adjustment0);
+        (usmOut, adjShrinkFactor) = usmFromMint(ls, msg.value);
         require(usmOut >= minUsmOut, "Limit not reached");
 
-        // 3. Update storedBuySellAdjustment and mint the user's new USM:
-        _storeBuySellAdjustment(adjustment0.wadMulDown(adjShrinkFactor));
-        _storePrice(ethUsdPrice0.wadMulDown(adjShrinkFactor), priceUpdateTime);
+        // 5. Update the in-memory LoadedState's buySellAdjustment and price:
+        ls.buySellAdjustment = ls.buySellAdjustment.wadMulDown(adjShrinkFactor);
+        ls.ethUsdPrice = ls.ethUsdPrice.wadMulDown(adjShrinkFactor);
+
+        // 6. Store the updated state and mint the user's new USM:
+        _storeState(ls);
         _mint(to, usmOut);
     }
 
     function _burnUsm(address from, address payable to, uint usmToBurn, uint minEthOut) internal returns (uint ethOut)
     {
-        // 1. Calculate ethOut:
-        (uint ethUsdPrice0, uint priceUpdateTime, uint adjustment0, ) = _refreshPrice();
-        uint ethInPool = ethPool();
+        // 1. Load the stored state:
+        LoadedState memory ls = loadState();
+
+        // 2. Refresh the oracle price:
+        (ls.ethUsdPrice, ls.ethUsdPriceTimestamp, ls.buySellAdjustment, ) = _refreshPrice(ls);
+
+        // 3. Calculate ethOut:
         uint adjGrowthFactor;
-        (ethOut, adjGrowthFactor) = ethFromBurn(ethUsdPrice0, usmToBurn, ethInPool, adjustment0);
+        (ethOut, adjGrowthFactor) = ethFromBurn(ls, usmToBurn);
         require(ethOut >= minEthOut, "Limit not reached");
 
-        // 2. Burn the input USM, update storedBuySellAdjustment, and return the user's ETH:
-        uint newDebtRatio = debtRatio(ethUsdPrice0, ethInPool - ethOut, totalSupply() - usmToBurn);
+        // 4. Update the in-memory LoadedState's buySellAdjustment and price:
+        ls.buySellAdjustment = ls.buySellAdjustment.wadMulUp(adjGrowthFactor);
+        ls.ethUsdPrice = ls.ethUsdPrice.wadMulUp(adjGrowthFactor);
+
+        // 5. Check that the burn didn't leave debt ratio > 100%:
+        uint newDebtRatio = debtRatio(ls.ethUsdPrice, ls.ethPool - ethOut, ls.usmTotalSupply - usmToBurn);
         require(newDebtRatio <= WAD, "Debt ratio > 100%");
+
+        // 6. Burn the input USM, store the updated state, and return the user's ETH:
         _burn(from, usmToBurn);
-        _storeBuySellAdjustment(adjustment0.wadMulUp(adjGrowthFactor));
-        _storePrice(ethUsdPrice0.wadMulUp(adjGrowthFactor), priceUpdateTime);
+        _storeState(ls);
         to.sendValue(ethOut);
     }
 
     function _fundFum(address to, uint minFumOut) internal returns (uint fumOut)
     {
-        // 1. Refresh mfbp:
-        (uint ethUsdPrice0, uint priceUpdateTime, uint adjustment0, ) = _refreshPrice();
-        uint rawEthInPool = ethPool();
-        uint ethInPool = rawEthInPool - msg.value;   // Backing out the ETH just received, which our calculations should ignore
-        uint usmSupply = totalSupply();
-        uint fumSupply = fum.totalSupply();
-        _updateMinFumBuyPrice(ethUsdPrice0, ethInPool, usmSupply, fumSupply);
+        // 1. Load the stored state:
+        LoadedState memory ls = loadState();
+        ls.ethPool -= msg.value;    // Backing out the ETH just received, which our calculations should ignore
 
-        // 2. Calculate fumOut:
+        // 2. Refresh the oracle price:
+        (ls.ethUsdPrice, ls.ethUsdPriceTimestamp, ls.buySellAdjustment, ) = _refreshPrice(ls);
+
+        // 3. Refresh timeSystemWentUnderwater:
+        uint usmSupplyForFumBuy;
+        (ls.timeSystemWentUnderwater, usmSupplyForFumBuy) =
+            checkIfUnderwater(ls.usmTotalSupply, ls.ethPool, ls.ethUsdPrice, ls.timeSystemWentUnderwater);
+
+        // 4. Calculate fumOut:
+        uint fumSupply = fum.totalSupply();
         uint adjGrowthFactor;
-        (fumOut, adjGrowthFactor) = fumFromFund(ethUsdPrice0, msg.value, ethInPool, usmSupply, fumSupply, adjustment0);
+        (fumOut, adjGrowthFactor) = fumFromFund(ls, usmSupplyForFumBuy, fumSupply, msg.value);
         require(fumOut >= minFumOut, "Limit not reached");
 
-        // 3. Update storedBuySellAdjustment and mint the user's new FUM:
-        _storeBuySellAdjustment(adjustment0.wadMulUp(adjGrowthFactor));
-        _storePrice(ethUsdPrice0.wadMulUp(adjGrowthFactor), priceUpdateTime);
+        // 5. Update the in-memory LoadedState's buySellAdjustment and price:
+        ls.buySellAdjustment = ls.buySellAdjustment.wadMulUp(adjGrowthFactor);
+        ls.ethUsdPrice = ls.ethUsdPrice.wadMulUp(adjGrowthFactor);
+
+        // 6. Update the stored state and mint the user's new FUM:
+        _storeState(ls);
         fum.mint(to, fumOut);
     }
 
     function _defundFum(address from, address payable to, uint fumToBurn, uint minEthOut) internal returns (uint ethOut)
     {
-        // 1. Calculate ethOut:
-        (uint ethUsdPrice0, uint priceUpdateTime, uint adjustment0, ) = _refreshPrice();
-        uint ethInPool = ethPool();
-        uint usmSupply = totalSupply();
+        // 1. Load the stored state:
+        LoadedState memory ls = loadState();
+
+        // 2. Refresh the oracle price:
+        (ls.ethUsdPrice, ls.ethUsdPriceTimestamp, ls.buySellAdjustment, ) = _refreshPrice(ls);
+
+        // 3. Calculate ethOut:
+        uint fumSupply = fum.totalSupply();
         uint adjShrinkFactor;
-        (ethOut, adjShrinkFactor) = ethFromDefund(ethUsdPrice0, fumToBurn, ethInPool, usmSupply, adjustment0);
+        (ethOut, adjShrinkFactor) = ethFromDefund(ls, fumSupply, fumToBurn);
         require(ethOut >= minEthOut, "Limit not reached");
 
-        // 2. Burn the input FUM, update storedBuySellAdjustment, and return the user's ETH:
-        uint newDebtRatio = debtRatio(ethUsdPrice0, ethInPool - ethOut, usmSupply);
+        // 4. Update the in-memory LoadedState's buySellAdjustment and price:
+        ls.buySellAdjustment = ls.buySellAdjustment.wadMulDown(adjShrinkFactor);
+        ls.ethUsdPrice = ls.ethUsdPrice.wadMulDown(adjShrinkFactor);
+
+        // 5. Check that the defund didn't leave debt ratio > MAX_DEBT_RATIO:
+        uint newDebtRatio = debtRatio(ls.ethUsdPrice, ls.ethPool - ethOut, ls.usmTotalSupply);
         require(newDebtRatio <= MAX_DEBT_RATIO, "Debt ratio > max");
+
+        // 6. Burn the input FUM, store the updated state, and return the user's ETH:
         fum.burn(from, fumToBurn);
-        _storeBuySellAdjustment(adjustment0.wadMulDown(adjShrinkFactor));
-        _storePrice(ethUsdPrice0.wadMulDown(adjShrinkFactor), priceUpdateTime);
+        _storeState(ls);
         to.sendValue(ethOut);
     }
 
-    function _refreshPrice() internal returns (uint price, uint updateTime, uint adjustment, bool priceChanged) {
+    function _refreshPrice(LoadedState memory ls)
+        internal returns (uint price, uint updateTime, uint adjustment, bool priceChanged)
+    {
         (price, updateTime) = oracle.refreshPrice();
-        adjustment = buySellAdjustment();
-        priceChanged = updateTime > storedPrice.timestamp;
-        if (priceChanged) {
+
+        // The rest of this fn should be non-transactional: only the oracle.refreshPrice() call above may affect storage.
+        adjustment = ls.buySellAdjustment;
+        priceChanged = updateTime > ls.ethUsdPriceTimestamp;
+
+        if (!priceChanged) {                // If the price isn't fresher than our old one, scrap it and stick to the old one
+            (price, updateTime) = (ls.ethUsdPrice, ls.ethUsdPriceTimestamp);
+        } else if (ls.ethUsdPrice != 0) {   // If the old price is 0, don't try to use it to adjust the buySellAdjustment...
             /**
              * This is a bit subtle.  We want to update the mid stored price to the oracle's fresh value, while updating
              * buySellAdjustment in such a way that the currently adjusted (more expensive than mid) side gets no
@@ -272,80 +328,55 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
              */
             if (adjustment > WAD) {
                 // max(1, old buy price / new mid price):
-                adjustment = WAD.wadMax(uint(storedPrice.value) * adjustment / price);
+                adjustment = WAD.wadMax(ls.ethUsdPrice * adjustment / price);
             } else if (adjustment < WAD) {
                 // min(1, old sell price / new mid price):
-                adjustment = WAD.wadMin(uint(storedPrice.value) * adjustment / price);
+                adjustment = WAD.wadMin(ls.ethUsdPrice * adjustment / price);
             }
-        } else {
-            (price, updateTime) = (storedPrice.value, storedPrice.timestamp);
         }
     }
 
     /**
-     * @notice Set the min FUM price, based on the current oracle price and debt ratio. Emits a MinFumBuyPriceChanged event.
-     * @dev The logic for calculating a new minFumBuyPrice is as follows.  We want to set it to the FUM price, in ETH terms, at
-     * which debt ratio was exactly MAX_DEBT_RATIO.  So we can assume:
-     *
-     *     usmToEth(totalSupply()) / ethPool() = MAX_DEBT_RATIO, or in other words:
-     *     usmToEth(totalSupply()) = MAX_DEBT_RATIO * ethPool()
-     *
-     * And with this assumption, we calculate the FUM price (buffer / FUM qty) like so:
-     *
-     *     minFumBuyPrice = ethBuffer() / fum.totalSupply()
-     *                    = (ethPool() - usmToEth(totalSupply())) / fum.totalSupply()
-     *                    = (ethPool() - (MAX_DEBT_RATIO * ethPool())) / fum.totalSupply()
-     *                    = (1 - MAX_DEBT_RATIO) * ethPool() / fum.totalSupply()
+     * @notice Stores the current price, `buySellAdjustment`, and `timeSystemWentUnderwater`.  Note that whereas most calls
+     * to this function store a fresh `buySellAdjustmentTimestamp`, most calls do *not* store a fresh `ethUsdPriceTimestamp`:
+     * the latter isn't updated every time this is called with a new price, but only when the *oracle's* price is refreshed.
+     * The oracle price being "refreshed" is itself a subtle idea: see the comment in `OurUniswapV2TWAPOracle._latestPrice()`.
      */
-    function _updateMinFumBuyPrice(uint ethUsdPrice, uint ethInPool, uint usmSupply, uint fumSupply) internal {
-        uint previous = storedMinFumBuyPrice.value;
-        uint debtRatio_ = debtRatio(ethUsdPrice, ethInPool, usmSupply);
-        if (debtRatio_ <= MAX_DEBT_RATIO) {                 // We've dropped below (or were already below, whatev) max debt ratio
-            if (previous != 0) {
-                storedMinFumBuyPrice.timestamp = 0;         // Clear mfbp
-                storedMinFumBuyPrice.value = 0;
-                emit MinFumBuyPriceChanged(previous, 0);
-            }
-        } else if (previous == 0) {                         // We were < max debt ratio, but have now crossed above - so set mfbp
-            // See reasoning in @dev comment above
-            uint mfbp = (WAD - MAX_DEBT_RATIO).wadMulUp(ethInPool).wadDivUp(fumSupply);
-            require(mfbp <= type(uint224).max, "mfbp overflow");
-            storedMinFumBuyPrice.timestamp = uint32(block.timestamp);
-            storedMinFumBuyPrice.value = uint224(mfbp);
-            emit MinFumBuyPriceChanged(previous, storedMinFumBuyPrice.value);
-        }
-    }
+    function _storeState(LoadedState memory ls) internal {
+        StoredState memory ss;
 
-    /**
-     * @notice Store the new ETH mid price after a price-moving operation.  Note that storedPrice.timestamp is *not* updated
-     * every time this is called with a fresh value, but only when the oracle's price is refreshed - itself a subtle idea: see
-     * the comment in `OurUniswapV2TWAPOracle._latestPrice()`.
-     */
-    function _storePrice(uint newPrice, uint updateTime) internal {
-        uint previous = storedPrice.value;
+        uint previousTimeUnderwater = storedState.timeSystemWentUnderwater;
+        require(ls.timeSystemWentUnderwater <= type(uint32).max, "timeSystemWentUnderwater overflow");
+        ss.timeSystemWentUnderwater = uint32(ls.timeSystemWentUnderwater);
+        emit PriceChanged(previousTimeUnderwater, ls.timeSystemWentUnderwater);
 
-        require(newPrice <= type(uint224).max, "newPrice overflow");
-        storedPrice.timestamp = uint32(updateTime);
-        storedPrice.value = uint224(newPrice);
-        emit PriceChanged(previous, newPrice);
-    }
+        require(ls.ethUsdPriceTimestamp <= type(uint32).max, "ethUsdPriceTimestamp overflow");
+        ss.ethUsdPriceTimestamp = uint32(ls.ethUsdPriceTimestamp);
 
-    /**
-     * @notice Store the new buy/sell adjustment factor, as of the current block time, after a price-moving operation.
-     */
-    function _storeBuySellAdjustment(uint newAdjustment) internal {
-        uint previous = storedBuySellAdjustment.value; // Not nec same as current buySellAdjustment(), due to the time decay!
+        uint previousPrice = storedState.ethUsdPrice * BILLION;
+        uint priceToStore = ls.ethUsdPrice + HALF_BILLION;
+        unchecked { priceToStore /= BILLION; }
+        require(priceToStore <= type(uint80).max, "ethUsdPrice overflow");
+        ss.ethUsdPrice = uint80(priceToStore);
+        emit PriceChanged(previousPrice, ls.ethUsdPrice);
 
-        require(newAdjustment <= type(uint224).max, "newAdjustment overflow");
-        storedBuySellAdjustment.timestamp = uint32(block.timestamp);
-        storedBuySellAdjustment.value = uint224(newAdjustment);
-        emit BuySellAdjustmentChanged(previous, newAdjustment);
+        require(ls.buySellAdjustmentTimestamp <= type(uint32).max, "buySellAdjustmentTimestamp overflow");
+        ss.buySellAdjustmentTimestamp = uint32(ls.buySellAdjustmentTimestamp);
+
+        uint previousAdjustment = storedState.buySellAdjustment * BILLION;
+        uint adjustmentToStore = ls.buySellAdjustment + HALF_BILLION;
+        unchecked { adjustmentToStore /= BILLION; }
+        require(adjustmentToStore <= type(uint80).max, "buySellAdjustment overflow");
+        ss.buySellAdjustment = uint80(adjustmentToStore);
+        emit BuySellAdjustmentChanged(previousAdjustment, ls.buySellAdjustment);
+
+        storedState = ss;
     }
 
     // ____________________ Public Oracle view functions ____________________
 
     function latestPrice() public virtual override(IUSM, Oracle) view returns (uint price, uint updateTime) {
-        (price, updateTime) = (storedPrice.value, storedPrice.timestamp);
+        (price, updateTime) = (storedState.ethUsdPrice * BILLION, storedState.ethUsdPriceTimestamp);
     }
 
     // ____________________ Public informational view functions ____________________
@@ -371,15 +402,74 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
     }
 
     /**
-     * @notice The current min FUM buy price, equal to the stored value decayed by time since minFumBuyPriceTimestamp.
-     * @return mfbp The minFumBuyPrice, in ETH terms
+     * @notice The current buy/sell adjustment, equal to the stored value decayed over time towards its stable value, 1.  This
+     * adjustment is intended as a measure of "how long-ETH recent user activity has been", so that we can slide price
+     * accordingly: if recent activity was mostly long-ETH (fund() and burn()), raise FUM buy price/reduce USM sell price; if
+     * recent activity was short-ETH (defund() and mint()), reduce FUM sell price/raise USM buy price.
+     * @return adjustment The sliding-price buy/sell adjustment
      */
-    function minFumBuyPrice() public view returns (uint mfbp) {
-        if (storedMinFumBuyPrice.value != 0) {
-            uint numHalvings = (block.timestamp - storedMinFumBuyPrice.timestamp).wadDivDown(MIN_FUM_BUY_PRICE_HALF_LIFE);
+    function buySellAdjustment() public override view returns (uint adjustment) {
+        adjustment = loadState().buySellAdjustment;
+    }
+
+    /**
+     * @return timeSystemWentUnderwater_ 0 the time at which we first detected the system was underwater (debt ratio >
+     * MAX_DEBT_RATIO), based on the current oracle price and pool ETH and USM; or 0 if we're not currently underwater.
+     * @return usmSupplyForFumBuys The current supply of USM *for purposes of calculating the FUM buy price,* and therefore
+     * for `fumFromFund()`.  The "supply for FUM buys" is the *lesser* of the actual current USM supply, and the USM amount
+     * that would make debt ratio = MAX_DEBT_RATIO.  Example:
+     *
+     * 1. Suppose the system currently contains 50 ETH at price $1,000 (total pool value: $50,000), with an actual USM supply
+     *    of 30,000 USM.  Then debt ratio = 30,000 / $50,000 = 60%: < MAX 80%, so `usmSupplyForFumBuys` = 30,000.
+     * 2. Now suppose ETH/USD halves to $500.  Then pool value halves to $25,000, and debt ratio doubles to 120%.  Now
+     *    `usmSupplyForFumBuys` instead = 20,000: the USM quantity at which debt ratio would equal 80% (20,000 / $25,000).
+     *    (Call this the "80% supply".)
+     * 3. ...Except, we also gradually increase the supply over time while we remain underwater.  This has the effect of
+     *    *reducing* the FUM buy price inferred from that supply (higher USM supply -> smaller buffer -> lower FUM price).
+     *    The math we use gradually increases the supply from its initial "80% supply" value, where debt ratio = MAX_DEBT_RATIO
+     *    (20,000 above), to a theoretical maximum "100% supply" value, where debt ratio = 100% (in the $500 example above,
+     *    this would be 25,000).  (Or the actual supply, whichever is lower: we never increase `usmSupplyForFumBuys` above
+     *    `usmActualSupply`.)  The climb from the initial 80% supply (20,000) to the 100% supply (25,000) is at a rate that
+     *    brings it "halfway closer per MIN_FUM_BUY_PRICE_HALF_LIFE (eg, 1 day)": so three days after going underwater, the
+     *    supply returned will be 25,000 - 0.5**3 * (25,000 - 20,000) = 24,375.
+     */
+    function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater)
+        public override view returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys)
+    {
+        uint debtRatio_ = debtRatio(ethUsdPrice, ethPool_, usmActualSupply);
+        if (debtRatio_ <= MAX_DEBT_RATIO) {            // We're not underwater, so leave timeSystemWentUnderwater_ as 0
+            usmSupplyForFumBuys = usmActualSupply;     // When not underwater, USM supply for FUM buys is just actual supply
+        } else {                                       // We're underwater
+            // Set timeSystemWentUnderwater_ to block.timestamp, if it wasn't already set:
+            timeSystemWentUnderwater_ = (oldTimeUnderwater != 0 ? oldTimeUnderwater : block.timestamp);
+
+            // Calculate usmSupplyForFumBuys:
+            uint maxEffectiveDebtRatio = debtRatio_.wadMin(WAD);    // min(actual debt ratio, 100%)
+            uint numHalvings = (block.timestamp - timeSystemWentUnderwater_).wadDivDown(MIN_FUM_BUY_PRICE_HALF_LIFE);
             uint decayFactor = numHalvings.wadHalfExp();
-            mfbp = uint256(storedMinFumBuyPrice.value).wadMulUp(decayFactor);
-        }   // Otherwise just returns 0
+            uint effectiveDebtRatio = maxEffectiveDebtRatio - decayFactor.wadMulUp(maxEffectiveDebtRatio - MAX_DEBT_RATIO);
+            usmSupplyForFumBuys = effectiveDebtRatio.wadMulDown(ethPool_.wadMulDown(ethUsdPrice));
+        }
+    }
+
+    function timeSystemWentUnderwater() public override view returns (uint timestamp) {
+        timestamp = storedState.timeSystemWentUnderwater;
+    }
+
+    // ____________________ Public helper view functions (for functions above) ____________________
+
+    function loadState() public view returns (LoadedState memory ls) {
+        ls.timeSystemWentUnderwater = storedState.timeSystemWentUnderwater;
+        ls.ethUsdPriceTimestamp = storedState.ethUsdPriceTimestamp;
+        ls.ethUsdPrice = storedState.ethUsdPrice * BILLION;     // Converting stored BILLION (10**9) format to WAD (10**18)
+        ls.buySellAdjustmentTimestamp = storedState.buySellAdjustmentTimestamp;
+        ls.buySellAdjustment = storedState.buySellAdjustment * BILLION;
+        ls.ethPool = ethPool();
+        ls.usmTotalSupply = totalSupply();
+
+        // Bring buySellAdjustment from its stored time to the present - it gravitates towards 1 over time:
+        ls.buySellAdjustment = buySellAdjustment(ls.buySellAdjustmentTimestamp, ls.buySellAdjustment, block.timestamp);
+        ls.buySellAdjustmentTimestamp = block.timestamp;
     }
 
     // ____________________ Public helper pure functions (for functions above) ____________________
@@ -399,12 +489,12 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
 
     /**
      * @notice Calculate debt ratio for a given eth to USM price: ratio of the outstanding USM (amount of USM in total supply), to
-     * the current ETH pool amount.
+     * the current ETH pool value in USD (ETH qty * ETH/USD price).
      * @return ratio Debt ratio
      */
     function debtRatio(uint ethUsdPrice, uint ethInPool, uint usmSupply) public override pure returns (uint ratio) {
         uint ethPoolValueInUsd = ethInPool.wadMulDown(ethUsdPrice);
-        ratio = (ethInPool == 0 ? 0 : usmSupply.wadDivUp(ethPoolValueInUsd));
+        ratio = (ethPoolValueInUsd == 0 ? 0 : usmSupply.wadDivUp(ethPoolValueInUsd));
     }
 
     /**
@@ -439,55 +529,46 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
     }
 
     /**
-     * @notice Calculate the *marginal* price of FUM (in ETH terms) - that is, of the next unit, before the price start sliding.
+     * @notice Calculate the *marginal* price of FUM (in ETH terms): that is, of the next unit, before the price start sliding.
+     * @param usmEffectiveSupply should be either the actual current USM supply, or, when calculating the FUM *buy* price, the
+     * `usmSupplyForFumBuys` return value from `checkIfUnderwater()`.
      * @return price FUM price in ETH terms
      */
-    function fumPrice(IUSM.Side side, uint ethUsdPrice, uint ethInPool, uint usmSupply, uint fumSupply, uint adjustment)
-        public override view returns (uint price)
+    function fumPrice(IUSM.Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply,
+                      uint adjustment)
+        public override pure returns (uint price)
     {
         WadMath.Round upOrDown = (side == IUSM.Side.Buy ? WadMath.Round.Up : WadMath.Round.Down);
         if (fumSupply == 0) {
             return usmToEth(ethUsdPrice, WAD, upOrDown);    // if no FUM issued yet, default fumPrice to 1 USD (in ETH terms)
         }
-        int buffer = ethBuffer(ethUsdPrice, ethInPool, usmSupply, upOrDown);
+
+        // Using usmEffectiveSupply here, rather than just the raw actual supply, has the effect of bumping the FUM price up to
+        // the minFumBuyPrice when needed (ie, debt ratio > MAX_DEBT_RATIO):
+        int buffer = ethBuffer(ethUsdPrice, ethInPool, usmEffectiveSupply, upOrDown);
         price = (buffer <= 0 ? 0 : uint(buffer).wadDiv(fumSupply, upOrDown));
 
         if (side == IUSM.Side.Buy) {
             if (adjustment > WAD) {
                 price = price.wadMulUp(adjustment);
             }
-            // Floor the buy price at minFumBuyPrice:
-            uint mfbp = minFumBuyPrice();
-            if (price < mfbp) {
-                price = mfbp;
-            }
-        } else {
-            if (adjustment < WAD) {
-                price = price.wadMulDown(adjustment);
-            }
+        } else if (adjustment < WAD) {
+            price = price.wadMulDown(adjustment);
         }
     }
 
     /**
-     * @notice The current buy/sell adjustment, equal to the stored value decayed by time since buySellAdjustmentTimestamp.  This
-     * adjustment is intended as a measure of "how long-ETH recent user activity has been", so that we can slide price
-     * accordingly: if recent activity was mostly long-ETH (fund() and burn()), raise FUM buy price/reduce USM sell price; if
-     * recent activity was short-ETH (defund() and mint()), reduce FUM sell price/raise USM buy price.  We use "it reduced debt
-     * ratio" as a rough proxy for "the operation was long-ETH".
-     *
-     * (There is one odd case: when debt ratio > 100%, a *short*-ETH mint() will actually reduce debt ratio.  This does no real
-     * harm except to make fast-succession mint()s and fund()s in such > 100% cases a little more expensive than they would be.)
-     *
-     * @return adjustment The sliding-price buy/sell adjustment
+     * @notice Returns the given stored buySellAdjustment value, updated (decayed towards 1) to the current time.
      */
-    function buySellAdjustment() public override view returns (uint adjustment) {
-        uint numHalvings = (block.timestamp - storedBuySellAdjustment.timestamp).wadDivDown(BUY_SELL_ADJUSTMENT_HALF_LIFE);
+    function buySellAdjustment(uint storedTime, uint storedAdjustment, uint currentTime) public pure returns (uint adjustment)
+    {
+        uint numHalvings = (currentTime - storedTime).wadDivDown(BUY_SELL_ADJUSTMENT_HALF_LIFE);
         uint decayFactor = numHalvings.wadHalfExp(10);
         // Here we use the idea that for any b and 0 <= p <= 1, we can crudely approximate b**p by 1 + (b-1)p = 1 + bp - p.
         // Eg: 0.6**0.5 pulls 0.6 "about halfway" to 1 (0.8); 0.6**0.25 pulls 0.6 "about 3/4 of the way" to 1 (0.9).
         // So b**p =~ b + (1-p)(1-b) = b + 1 - b - p + bp = 1 + bp - p.
         // (Don't calculate it as 1 + (b-1)p because we're using uints, b-1 can be negative!)
-        adjustment = WAD + uint256(storedBuySellAdjustment.value).wadMulDown(decayFactor) - decayFactor;
+        adjustment = WAD + storedAdjustment.wadMulDown(decayFactor) - decayFactor;
     }
 
     /**
@@ -495,17 +576,17 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
      * @param ethIn The amount of ETH passed to mint()
      * @return usmOut The amount of USM to receive in exchange
      */
-    function usmFromMint(uint ethUsdPrice0, uint ethIn, uint ethQty0, uint adjustment0)
+    function usmFromMint(LoadedState memory ls, uint ethIn)
         public pure returns (uint usmOut, uint adjShrinkFactor)
     {
         // Create USM at a sliding-up USM price (ie, a sliding-down ETH price):
-        uint usmBuyPrice0 = usmPrice(IUSM.Side.Buy, ethUsdPrice0, adjustment0);
-        uint ethQty1 = ethQty0 + ethIn;
-        //adjShrinkFactor = ethQty0.wadDivDown(ethQty1).wadSqrt();      // Another possible function we could use (same result)
-        adjShrinkFactor = ethQty0.wadDivDown(ethQty1).wadExp(HALF_WAD);
-        int log = ethQty1.wadDivDown(ethQty0).wadLog();
+        uint usmBuyPrice0 = usmPrice(IUSM.Side.Buy, ls.ethUsdPrice, ls.buySellAdjustment);
+        uint ethPool1 = ls.ethPool + ethIn;
+        //adjShrinkFactor = ls.ethPool.wadDivDown(ethPool1).wadSqrt();      // Another possible function we could use (same result)
+        adjShrinkFactor = ls.ethPool.wadDivDown(ethPool1).wadExp(HALF_WAD);
+        int log = ethPool1.wadDivDown(ls.ethPool).wadLog();
         require(log >= 0, "log underflow");
-        usmOut = ethQty0.wadDivDown(usmBuyPrice0).wadMulDown(uint(log));
+        usmOut = ls.ethPool.wadDivDown(usmBuyPrice0).wadMulDown(uint(log));
     }
 
     /**
@@ -513,20 +594,18 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
      * @param usmIn The amount of USM passed to burn()
      * @return ethOut The amount of ETH to receive in exchange
      */
-    function ethFromBurn(uint ethUsdPrice0, uint usmIn, uint ethQty0, uint adjustment0)
+    function ethFromBurn(LoadedState memory ls, uint usmIn)
         public pure returns (uint ethOut, uint adjGrowthFactor)
     {
         // Burn USM at a sliding-down USM price (ie, a sliding-up ETH price):
-        uint usmSellPrice0 = usmPrice(IUSM.Side.Sell, ethUsdPrice0, adjustment0);
+        uint usmSellPrice0 = usmPrice(IUSM.Side.Sell, ls.ethUsdPrice, ls.buySellAdjustment);
 
-        // Math: this is an integral - sum of all USM burned at a sliding price.  Follows the same mathematical invariant as
-        // above: if debtRatio() *= k (here, k < 1), ETH price *= 1/k**2, ie, USM price in ETH terms *= k**2.
-        // e_0 - e = e_0 - (e_0**2 * (e_0 - usp_0 * u_0 * (1 - (u / u_0)**3)))**(1/3)
-        uint exponent = usmIn.wadMulUp(usmSellPrice0).wadDivUp(ethQty0);
+        // Math: this is an integral - sum of all USM burned at a sliding price.
+        uint exponent = usmIn.wadMulUp(usmSellPrice0).wadDivUp(ls.ethPool);
         require(exponent <= uint(type(int).max), "exponent overflow");
-        uint ethQty1 = ethQty0.wadDivUp(exponent.wadExp());
-        ethOut = ethQty0 - ethQty1;
-        adjGrowthFactor = ethQty0.wadDivUp(ethQty1).wadExp(HALF_WAD);
+        uint ethPool1 = ls.ethPool.wadDivUp(exponent.wadExp());
+        ethOut = ls.ethPool - ethPool1;
+        adjGrowthFactor = ls.ethPool.wadDivUp(ethPool1).wadExp(HALF_WAD);
     }
 
     /**
@@ -534,33 +613,26 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
      * @param ethIn The amount of ETH passed to fund()
      * @return fumOut The amount of FUM to receive in exchange
      */
-    function fumFromFund(uint ethUsdPrice0, uint ethIn, uint ethQty0, uint usmQty0, uint fumQty0, uint adjustment0)
-        public view returns (uint fumOut, uint adjGrowthFactor)
+    function fumFromFund(LoadedState memory ls, uint usmEffectiveSupply, uint fumSupply, uint ethIn)
+        public pure returns (uint fumOut, uint adjGrowthFactor)
     {
-        if (ethQty0 == 0) {
+        if (ls.ethPool == 0) {
             // No ETH in the system yet, which breaks our adjGrowthFactor calculation below - skip sliding-prices this time:
             adjGrowthFactor = WAD;
-            uint fumBuyPrice0 = fumPrice(IUSM.Side.Buy, ethUsdPrice0, ethQty0, usmQty0, fumQty0, adjustment0);
+            uint fumBuyPrice0 = fumPrice(IUSM.Side.Buy, ls.ethUsdPrice, ls.ethPool, usmEffectiveSupply, fumSupply,
+                                         ls.buySellAdjustment);
             fumOut = ethIn.wadDivDown(fumBuyPrice0);
         } else {
             // Create FUM at a sliding-up FUM price:
-            uint ethQty1 = ethQty0 + ethIn;
-            uint effectiveUsmQty0 = usmQty0.wadMin(ethQty0.wadMulUp(ethUsdPrice0).wadMulUp(MAX_DEBT_RATIO));
-            uint effectiveDebtRatio = debtRatio(ethUsdPrice0, ethQty0, effectiveUsmQty0);
+            uint ethPool1 = ls.ethPool + ethIn;
+            uint effectiveDebtRatio = debtRatio(ls.ethUsdPrice, ls.ethPool, usmEffectiveSupply);
             uint effectiveFumDelta = WAD.wadDivUp(WAD - effectiveDebtRatio);
-            adjGrowthFactor = ethQty1.wadDivUp(ethQty0).wadExp(effectiveFumDelta / 2);
-            fumOut = calcSlidingFumQty(ethUsdPrice0, ethIn, ethQty0, fumQty0, adjustment0, effectiveUsmQty0, adjGrowthFactor);
+            adjGrowthFactor = ethPool1.wadDivUp(ls.ethPool).wadExp(effectiveFumDelta / 2);
+            uint ethUsdPrice1 = ls.ethUsdPrice.wadMulUp(adjGrowthFactor);
+            uint avgFumBuyPrice = ls.buySellAdjustment.wadMulUp(
+                (ls.ethPool - usmEffectiveSupply.wadDivDown(ethUsdPrice1)).wadDivUp(fumSupply));
+            fumOut = ethIn.wadDivDown(avgFumBuyPrice);
         }
-    }
-
-    function calcSlidingFumQty(uint ethUsdPrice0, uint ethIn, uint ethQty0, uint fumQty0, uint adjustment0,
-                               uint effectiveUsmQty0, uint adjGrowthFactor)
-        public pure returns (uint fumOut)
-    {
-        uint ethUsdPrice1 = ethUsdPrice0.wadMulUp(adjGrowthFactor);
-        uint avgFumBuyPrice = adjustment0.wadMulUp(
-            (ethQty0 - effectiveUsmQty0.wadDivDown(ethUsdPrice1)).wadDivUp(fumQty0));
-        fumOut = ethIn.wadDivDown(avgFumBuyPrice);
     }
 
     /**
@@ -568,35 +640,34 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
      * @param fumIn The amount of FUM passed to defund()
      * @return ethOut The amount of ETH to receive in exchange
      */
-    function ethFromDefund(uint ethUsdPrice0, uint fumIn, uint ethQty0, uint usmQty0, uint adjustment0)
-        public view returns (uint ethOut, uint adjShrinkFactor)
+    function ethFromDefund(LoadedState memory ls, uint fumSupply, uint fumIn)
+        public pure returns (uint ethOut, uint adjShrinkFactor)
     {
         // Burn FUM at a sliding-down FUM price:
-        uint fumQty0 = fum.totalSupply();
-        uint debtRatio0 = debtRatio(ethUsdPrice0, ethQty0, usmQty0);
-        uint fumDelta = WAD.wadDivUp(WAD - debtRatio0);
-        uint avgFumSellPrice = calcAverageFumSellPrice(ethUsdPrice0, fumIn, ethQty0, usmQty0, fumQty0, adjustment0, fumDelta);
-        ethOut = fumIn.wadMulDown(avgFumSellPrice);
-        uint ethQty1 = ethQty0 - ethOut;
-        adjShrinkFactor = ethQty1.wadDivUp(ethQty0).wadExp(fumDelta / 2);
-    }
+        //uint debtRatio0 = debtRatio(ls.ethUsdPrice, ls.ethPool, ls.usmTotalSupply);
+        //uint fumDelta = WAD.wadDivUp(WAD - debtRatio0);
+        uint fumDelta = WAD.wadDivUp(WAD - debtRatio(ls.ethUsdPrice, ls.ethPool, ls.usmTotalSupply));
 
-    function calcAverageFumSellPrice(uint ethUsdPrice0, uint fumIn, uint ethQty0, uint usmQty0, uint fumQty0, uint adjustment0,
-                                     uint fumDelta)
-        public view returns (uint avgFumSellPrice)
-    {
-        uint fumSellPrice0 = fumPrice(IUSM.Side.Sell, ethUsdPrice0, ethQty0, usmQty0, fumQty0, adjustment0);
+        uint fumSellPrice0 = fumPrice(IUSM.Side.Sell, ls.ethUsdPrice, ls.ethPool, ls.usmTotalSupply, fumSupply,
+                                      ls.buySellAdjustment);
 
         // First obtain a pessimistic upper bound on how large the adjShrinkFactor could be - pessimistic since the more the
         // adjustment shrinks, the more our sell price slides (down) away from us.  The more the ETH pool decreases, the more
         // the adjShrinkFactor drops.  And the amount by which the ETH pool would drop if our entire defund was at the starting
         // fumSellPrice0, is an upper bound on how much the pool could shrink.  Therefore, the adjShrinkFactor implied by that
         // maximum ETH pool reduction, is an upper bound on the actual adjShrinkFactor of this defund() call:
-        uint lowerBoundEthQty1 = ethQty0 - fumIn.wadMulUp(fumSellPrice0);
-        uint lowerBoundAdjShrinkFactor = lowerBoundEthQty1.wadDivDown(ethQty0).wadExp(fumDelta / 2);
-        uint lowerBoundEthUsdPrice1 = ethUsdPrice0.wadMulDown(lowerBoundAdjShrinkFactor);
+        //uint lowerBoundEthQty1 = ls.ethPool - fumIn.wadMulUp(fumSellPrice0);
+        //uint lowerBoundAdjShrinkFactor = lowerBoundEthQty1.wadDivDown(ls.ethPool).wadExp(fumDelta / 2);
+        uint lowerBoundAdjShrinkFactor = (ls.ethPool - fumIn.wadMulUp(fumSellPrice0)).wadDivDown(ls.ethPool).wadExp(
+            fumDelta / 2);
+        uint lowerBoundEthUsdPrice1 = ls.ethUsdPrice.wadMulDown(lowerBoundAdjShrinkFactor);
 
         // Using this ending ETH mid price lowerBoundEthUsdPrice1, we can calc the actual average FUM sell price of the defund:
-        avgFumSellPrice = fumPrice(IUSM.Side.Sell, lowerBoundEthUsdPrice1, ethQty0, usmQty0, fumQty0, adjustment0);
+        uint avgFumSellPrice = fumPrice(IUSM.Side.Sell, lowerBoundEthUsdPrice1, ls.ethPool, ls.usmTotalSupply, fumSupply,
+                                        ls.buySellAdjustment);
+
+        ethOut = fumIn.wadMulDown(avgFumSellPrice);
+        uint ethPool1 = ls.ethPool - ethOut;
+        adjShrinkFactor = ethPool1.wadDivUp(ls.ethPool).wadExp(fumDelta / 2);
     }
 }

--- a/contracts/USMView.sol
+++ b/contracts/USMView.sol
@@ -70,7 +70,12 @@ contract USMView {
      */
     function fumPrice(IUSM.Side side) external view returns (uint price) {
         (uint ethUsdPrice, ) = usm.latestPrice();
-        price = usm.fumPrice(side, ethUsdPrice, usm.ethPool(), usm.usmTotalSupply(), usm.fumTotalSupply(),
-                             usm.buySellAdjustment());
+        uint ethPool_ = usm.ethPool();
+        uint usmSupply = usm.usmTotalSupply();
+        uint oldTimeUnderwater = usm.timeSystemWentUnderwater();
+        if (side == IUSM.Side.Buy) {
+            (, usmSupply) = usm.checkIfUnderwater(usmSupply, ethPool_, ethUsdPrice, oldTimeUnderwater);
+        }
+        price = usm.fumPrice(side, ethUsdPrice, ethPool_, usmSupply, usm.fumTotalSupply(), usm.buySellAdjustment());
     }
 }


### PR DESCRIPTION
1. Instead of storing minFumBuyPrice when we're underwater, just store the *time* at which we went underwater, which I realized is all we need to infer the minFumBuyPrice.  This is also a behavioral change: formerly, the FUM buy price could *suddenly drop* once debt ratio went back below the max (ugly that buying FUM caused FUM price to drop - bad incentives); now it behaves continuously across that threshold - nicer.
2. I also changed how we manage stored state: packing all our stored vars into one 256-bit word, loading it at the start of each external function call, and saving all changes in one shot at the end.  Saves a bit of gas (~2k-5k per call) - may be able to tighten that up further, haven't really tried.
I tried to separate these into two commits but it was too hard...  Minimal changes to the tests here (which still pass), so that's encouraging that not much behavior is changed.
Closes #91.