### PR TITLE
Fix emitting of underwater-status-changed events, and also tweak other event emitting

### DIFF
--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -29,7 +29,7 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
     using Address for address payable;
     using WadMath for uint;
 
-    event UnderwaterStatusChanged(bool previous, bool latest);
+    event TimeSystemWentUnderwaterChanged(uint previous, uint latest);
     event BuySellAdjustmentChanged(uint previous, uint latest);
     event PriceChanged(uint previous, uint latest);
 
@@ -344,24 +344,30 @@ contract USM is IUSM, Oracle, ERC20WithOptOut, Delegable {
      */
     function _storeState(LoadedState memory ls) internal {
         uint previousTimeUnderwater = storedState.timeSystemWentUnderwater;
-        require(ls.timeSystemWentUnderwater <= type(uint32).max, "timeSystemWentUnderwater overflow");
-        emit PriceChanged(previousTimeUnderwater, ls.timeSystemWentUnderwater);
+        if (ls.timeSystemWentUnderwater != previousTimeUnderwater) {
+            require(ls.timeSystemWentUnderwater <= type(uint32).max, "timeSystemWentUnderwater overflow");
+            emit TimeSystemWentUnderwaterChanged(previousTimeUnderwater, ls.timeSystemWentUnderwater);
+        }
 
         require(ls.ethUsdPriceTimestamp <= type(uint32).max, "ethUsdPriceTimestamp overflow");
 
-        uint previousPrice = storedState.ethUsdPrice * BILLION;
         uint priceToStore = ls.ethUsdPrice + HALF_BILLION;
         unchecked { priceToStore /= BILLION; }
-        require(priceToStore <= type(uint80).max, "ethUsdPrice overflow");
-        emit PriceChanged(previousPrice, ls.ethUsdPrice);
+        uint previousStoredPrice = storedState.ethUsdPrice;
+        if (priceToStore != previousStoredPrice) {
+            require(priceToStore <= type(uint80).max, "ethUsdPrice overflow");
+            unchecked { emit PriceChanged(previousStoredPrice * BILLION, priceToStore * BILLION); }
+        }
 
         require(ls.buySellAdjustmentTimestamp <= type(uint32).max, "buySellAdjustmentTimestamp overflow");
 
-        uint previousAdjustment = storedState.buySellAdjustment * BILLION;
         uint adjustmentToStore = ls.buySellAdjustment + HALF_BILLION;
         unchecked { adjustmentToStore /= BILLION; }
-        require(adjustmentToStore <= type(uint80).max, "buySellAdjustment overflow");
-        emit BuySellAdjustmentChanged(previousAdjustment, ls.buySellAdjustment);
+        uint previousStoredAdjustment = storedState.buySellAdjustment;
+        if (adjustmentToStore != previousStoredAdjustment) {
+            require(adjustmentToStore <= type(uint80).max, "buySellAdjustment overflow");
+            unchecked { emit BuySellAdjustmentChanged(previousStoredAdjustment * BILLION, adjustmentToStore * BILLION); }
+        }
 
         (storedState.timeSystemWentUnderwater,
          storedState.ethUsdPriceTimestamp, storedState.ethUsdPrice,


### PR DESCRIPTION
1. I was mistakenly emitting a `PriceChanged` event when the underwater status changed - wrong event.  Fixed.
2. In general, do we want to emit events every time the relevant function is called, even if the state var ends up unchanged (previous behavior); or only when state *changes* (behavior I introduce here)?  Fwiw the new code reduces test 3's average `mint()` gas consumption by 1.3k, due to sometimes skipping events (not sure we'd save that much on a typical production call).
3. I'm emitting `timeSystemWentUnderwater`, a timestamp.  I could instead emit a boolean, whether the system is underwater - less information but easier for event-readers to understand.