### PR TITLE
Simplify OurUniswapV2TWAPOracle constructor's args a bit

### DIFF
--- a/contracts/mocks/MockMedianOracle.sol
+++ b/contracts/mocks/MockMedianOracle.sol
@@ -13,10 +13,10 @@ contract MockMedianOracle is MedianOracle, SettableOracle {
     constructor(
         AggregatorV3Interface chainlinkAggregator,
         UniswapAnchoredView compoundView,
-        IUniswapV2Pair uniswapPair, uint uniswapToken0Decimals, uint uniswapToken1Decimals, bool uniswapTokensInReverseOrder
+        IUniswapV2Pair uniswapPair, uint uniswapTokenToUse, int uniswapTokenDecimals
     )
         MedianOracle(chainlinkAggregator, compoundView,
-            uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
+            uniswapPair, uniswapTokenToUse, uniswapTokenDecimals) {}
 
     function refreshPrice() public override(MedianOracle, Oracle) returns (uint price, uint updateTime) {
         (price, updateTime) = (savedPrice != 0) ? (savedPrice, savedUpdateTime) : super.refreshPrice();

--- a/contracts/oracles/MedianOracle.sol
+++ b/contracts/oracles/MedianOracle.sol
@@ -10,11 +10,11 @@ contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, OurUniswapV2TWAPOr
     constructor(
         AggregatorV3Interface chainlinkAggregator,
         UniswapAnchoredView compoundView,
-        IUniswapV2Pair uniswapPair, uint uniswapToken0Decimals, uint uniswapToken1Decimals, bool uniswapTokensInReverseOrder
+        IUniswapV2Pair uniswapPair, uint uniswapTokenToUse, int uniswapTokenDecimals
     )
         ChainlinkOracle(chainlinkAggregator)
         CompoundOpenOracle(compoundView)
-        OurUniswapV2TWAPOracle(uniswapPair, uniswapToken0Decimals, uniswapToken1Decimals, uniswapTokensInReverseOrder) {}
+        OurUniswapV2TWAPOracle(uniswapPair, uniswapTokenToUse, uniswapTokenDecimals) {}
 
     function latestPrice() public virtual override(ChainlinkOracle, CompoundOpenOracle, OurUniswapV2TWAPOracle)
         view returns (uint price, uint updateTime)

--- a/deploy/1_deploy_oracle.js
+++ b/deploy/1_deploy_oracle.js
@@ -21,12 +21,8 @@ const func = async function ({ deployments, getNamedAccounts, getChainId }) {
   const { deployer } = await getNamedAccounts();
   const chainId = await getChainId()
 
-  //const uniswapTokens0Decimals = [18, 6, 18]                // ETH/USDT, USDC/ETH, DAI/ETH.  See OurUniswapV2TWAPOracle
-  //const uniswapTokens1Decimals = [6, 18, 18]                // See UniswapMedianOracle
-  //const uniswapTokensInReverseOrder = [false, true, true]   // See UniswapMedianOracle
-  const usdcDecimals = 6                                      // See UniswapMedianOracle
-  const ethDecimals = 18                                      // See UniswapMedianOracle
-  const uniswapTokensInReverseOrder = true                    // See UniswapMedianOracle
+  const usdcEthTokenToUse = 1
+  const usdcEthEthDecimals = -12
 
   let aggregator, anchoredView, usdcEthPair
   let aggregatorAddress, anchoredViewAddress, usdcEthPairAddress
@@ -34,7 +30,7 @@ const func = async function ({ deployments, getNamedAccounts, getChainId }) {
   if (chainId === '31337') { // buidlerevm's chainId
     const chainlinkPrice = '38598000000' // 8 dec places: see ChainlinkOracle
     const compoundPrice = '414174999' // 6 dec places: see CompoundOpenOracle
-    const usdcEthCumPrice0 = '307631784275278277546624451305316303382174855535226'
+    const usdcEthCumPrice0 = 0 // We don't use token0 (for USDC/ETH) so whatever
     const usdcEthCumPrice1 = '31377639132666967530700283664103'
 
     aggregator = await deploy('MockChainlinkAggregatorV3', {
@@ -68,9 +64,8 @@ const func = async function ({ deployments, getNamedAccounts, getChainId }) {
         aggregatorAddress,
         anchoredViewAddress,
         usdcEthPairAddress,
-        usdcDecimals,
-        ethDecimals,
-        uniswapTokensInReverseOrder,
+        usdcEthTokenToUse,
+        usdcEthEthDecimals,
       ],
     })
     console.log(`Deployed MedianOracle to ${oracle.address}`);

--- a/deploy/oracle-args-1.js
+++ b/deploy/oracle-args-1.js
@@ -6,15 +6,13 @@ const addresses = {
     'daiEth': '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11',
 }
   
-const usdcDecimals = 6                                      // See UniswapMedianOracle
-const ethDecimals = 18                                      // See UniswapMedianOracle
-const uniswapTokensInReverseOrder = true                    // See UniswapMedianOracle
+const usdcEthTokenToUse = 1
+const usdcEthEthDecimals = -12
 
 module.exports = [
     addresses['chainlink'],
     addresses['compound'],
     addresses['usdcEth'],
-    usdcDecimals,
-    ethDecimals,
-    uniswapTokensInReverseOrder,
+    usdcEthTokenToUse,
+    usdcEthEthDecimals,
 ];

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -39,16 +39,12 @@ contract('USM', (accounts) => {
   const compoundPrice = '414174999'                         // 6 dec places: see CompoundOpenOracle
 
   let usdcEthPair
-  const usdcDecimals = SIX                                  // See UniswapMedianTWAPOracle
-  const ethDecimals = EIGHTEEN                              // See UniswapMedianTWAPOracle
-  const uniswapTokensInReverseOrder = true                  // See UniswapMedianTWAPOracle
-
-  const usdcEthCumPrice0_0 = new BN('307631784275278277546624451305316303382174855535226')  // From the USDC/ETH pair
-  const usdcEthCumPrice1_0 = new BN('31375939132666967530700283664103')
+  const usdcEthTokenToUse = new BN(1)                       // See OurUniswapV2TWAPOracle for explanations of these
+  const usdcEthCumPrice1_0 = new BN('31375939132666967530700283664103')     // From the USDC/ETH pair
   const usdcEthTimestamp_0 = new BN('1606780664')
-  const usdcEthCumPrice0_1 = new BN('307634635050611880719301156089846577363471806696356')
   const usdcEthCumPrice1_1 = new BN('31378725947216452626380862836246')
   const usdcEthTimestamp_1 = new BN('1606782003')
+  const usdcEthEthDecimals = new BN(-12)
 
   function wadMul(x, y, upOrDown) {
     return ((x.mul(y)).add(upOrDown == rounds.DOWN ? ZERO : WAD_MINUS_1)).div(WAD)
@@ -107,11 +103,11 @@ contract('USM', (accounts) => {
 
       usdcEthPair = await UniswapV2Pair.new({ from: deployer })
       await usdcEthPair.setReserves(0, 0, usdcEthTimestamp_0)
-      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_0, usdcEthCumPrice1_0)
+      await usdcEthPair.setCumulativePrices(0, usdcEthCumPrice1_0)
 
       // USM
       oracle = await MedianOracle.new(aggregator.address, anchoredView.address,
-                                      usdcEthPair.address, usdcDecimals, ethDecimals, uniswapTokensInReverseOrder,
+                                      usdcEthPair.address, usdcEthTokenToUse, usdcEthEthDecimals,
                                       { from: deployer })
       usm = await USM.new(oracle.address, [optOut1, optOut2], { from: deployer })
       await usm.refreshPrice()  // This call stores the Uniswap cumPriceSeconds record for time usdcEthTimestamp_0
@@ -119,7 +115,7 @@ contract('USM', (accounts) => {
       usmView = await USMView.new(usm.address, { from: deployer })
 
       await usdcEthPair.setReserves(0, 0, usdcEthTimestamp_1)
-      await usdcEthPair.setCumulativePrices(usdcEthCumPrice0_1, usdcEthCumPrice1_1)
+      await usdcEthPair.setCumulativePrices(0, usdcEthCumPrice1_1)
       await usm.refreshPrice()  // ...And this stores the cumPriceSeconds for usdcEthTimestamp_1 - so we have a valid TWAP now
 
       priceWAD = (await usm.latestPrice())[0]


### PR DESCRIPTION
This is not an important change, so we can scrap it if it seems like too much at this stage.  It does make things slightly simpler though while changing basically no code (aside from comments) outside of the `OurUniswapV2TWAPOracle` constructor (and code that uses it).