### PR TITLE
Final (?) updates to the fee math

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Originally proposed by [@jacob-eliosoff](https://github.com/jacob-eliosoff) in [
 
 ## Networks & Addresses
 
-### USM v0.2 (Kovan testnet)
+### USM v0.3 (Kovan testnet)
 
- - Oracle: [0x4B2D04f6d7721B09024E0d61C1617DF04e4C21ae](https://kovan.etherscan.io/address/0x4B2D04f6d7721B09024E0d61C1617DF04e4C21ae)
- - USM: [0x6dcc375aE1f43c8FA4e13D56E6ec584BeE25A88F](https://kovan.etherscan.io/address/0x6dcc375aE1f43c8FA4e13D56E6ec584BeE25A88F)
- - FUM: [0xf99b440d8e18f850187ae53cdd4ebc959ebf36df](https://kovan.etherscan.io/address/0xf99b440d8e18f850187ae53cdd4ebc959ebf36df)
- - USMView: [0x5442818E2E38FB2c8F4CEed22782663b8FCBD0b5](https://kovan.etherscan.io/address/0x5442818E2E38FB2c8F4CEed22782663b8FCBD0b5)
- - Proxy: [0xaCDCd6A936134D7C84163CD9B23B256cb25942D0](https://kovan.etherscan.io/address/0xaCDCd6A936134D7C84163CD9B23B256cb25942D0)
+ - Oracle: [0x8e91D25324833D62Fb3eC67aDEE26048696c8909](https://kovan.etherscan.io/address/0x8e91D25324833D62Fb3eC67aDEE26048696c8909)
+ - USM: [0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67](https://kovan.etherscan.io/address/0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67)
+ - FUM: [0x0f682f36363b4cd5261dd613f4caec6e6c8a5eef](https://kovan.etherscan.io/address/0x0f682f36363b4cd5261dd613f4caec6e6c8a5eef)
+ - USMView: [0xfd1B7a306D0a28d886f15Fb0D2F4d8A720E10B4c](https://kovan.etherscan.io/address/0xfd1B7a306D0a28d886f15Fb0D2F4d8A720E10B4c)
+ - Proxy: [0xa026638f21E6f1deD6dE7A6bd1DB8b4376A49b68](https://kovan.etherscan.io/address/0xa026638f21E6f1deD6dE7A6bd1DB8b4376A49b68)
 
 ### USM v0.1 ("Baby USM") - Mainnet
 
@@ -23,12 +23,6 @@ Baby USM and Baby FUM is not redeemable for USM or FUM. It is for test and reser
 USM: [0x03eb7Ce2907e202bB70BAE3D7B0C588573d3cECC](https://etherscan.io/address/0x03eb7Ce2907e202bB70BAE3D7B0C588573d3cECC)
 
 FUM: [0xf04a5D82ff8a801f7d45e9C14CDcf73defF1a394](https://etherscan.io/address/0xf04a5D82ff8a801f7d45e9C14CDcf73defF1a394)
-
-### Kovan
-
-USM: [0x21453979384f21D09534f8801467BDd5d90eCD6C](https://kovan.etherscan.io/address/0x21453979384f21D09534f8801467BDd5d90eCD6C)
-
-FUM: [0x96F8F5323Aa6CB0e6F311bdE6DEEFb1c81Cb1898](https://kovan.etherscan.io/address/0x96F8F5323Aa6CB0e6F311bdE6DEEFb1c81Cb1898)
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Originally proposed by [@jacob-eliosoff](https://github.com/jacob-eliosoff) in [
 
 ## Networks & Addresses
 
-### USM v0.3 (Kovan testnet)
+### USM v0.4 (Kovan testnet)
 
  - Oracle: [0x8e91D25324833D62Fb3eC67aDEE26048696c8909](https://kovan.etherscan.io/address/0x8e91D25324833D62Fb3eC67aDEE26048696c8909)
- - USM: [0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67](https://kovan.etherscan.io/address/0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67)
- - FUM: [0x0f682f36363b4cd5261dd613f4caec6e6c8a5eef](https://kovan.etherscan.io/address/0x0f682f36363b4cd5261dd613f4caec6e6c8a5eef)
- - USMView: [0xfd1B7a306D0a28d886f15Fb0D2F4d8A720E10B4c](https://kovan.etherscan.io/address/0xfd1B7a306D0a28d886f15Fb0D2F4d8A720E10B4c)
- - Proxy: [0xa026638f21E6f1deD6dE7A6bd1DB8b4376A49b68](https://kovan.etherscan.io/address/0xa026638f21E6f1deD6dE7A6bd1DB8b4376A49b68)
+ - USM: [0x7dbC406E09c876C77949A45BBE4173Aa6CdF9470](https://kovan.etherscan.io/address/0x7dbC406E09c876C77949A45BBE4173Aa6CdF9470)
+ - FUM: [0x6ee47863a96a488a53053dea290ccf7f8979d6a9](https://kovan.etherscan.io/address/0x6ee47863a96a488a53053dea290ccf7f8979d6a9)
+ - USMView: [0x14E1657013b721B341eA27fcA47538C3B7416E4c](https://kovan.etherscan.io/address/0x14E1657013b721B341eA27fcA47538C3B7416E4c)
+ - Proxy: [0x4096DACc67Bae0F5b762D5DF98B343B0AaBAc1C0](https://kovan.etherscan.io/address/0x4096DACc67Bae0F5b762D5DF98B343B0AaBAc1C0)
 
 ### USM v0.1 ("Baby USM") - Mainnet
 

--- a/contracts/Delegable.sol
+++ b/contracts/Delegable.sol
@@ -7,8 +7,7 @@ pragma solidity ^0.8.0;
 contract Delegable {
     event Delegate(address indexed user, address indexed delegate, bool enabled);
 
-    // keccak256("Signature(address user,address delegate,uint256 nonce,uint256 deadline)");
-    bytes32 public constant SIGNATURE_TYPEHASH = 0x0d077601844dd17f704bafff948229d27f33b57445915754dfe3d095fda2beb7;
+    bytes32 public constant SIGNATURE_TYPEHASH = keccak256("Signature(address user,address delegate,uint256 nonce,uint256 deadline)"); // 0x0d077601844dd17f704bafff948229d27f33b57445915754dfe3d095fda2beb7;
     bytes32 public immutable DELEGABLE_DOMAIN;
     mapping(address => uint) public signatureCount;
 
@@ -48,6 +47,11 @@ contract Delegable {
     /// @dev Stop a delegate from acting on the behalf of caller
     function revokeDelegate(address delegate) public {
         _revokeDelegate(msg.sender, delegate);
+    }
+
+    /// @dev Allow a delegate to renounce to its delegation
+    function renounceDelegate(address user) public {
+        _revokeDelegate(user, msg.sender);
     }
 
     /// @dev Add a delegate through an encoded signature

--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -19,7 +19,7 @@ contract FUM is ERC20Permit, WithOptOut, Ownable {
     IUSM public immutable usm;
 
     constructor(IUSM usm_, address[] memory optedOut_)
-        ERC20Permit("Minimalist Funding v1.0 - Test 3", "FUMTest")
+        ERC20Permit("Minimalist Funding v1.0 - Test 4", "FUMTest")
         WithOptOut(optedOut_)
     {
         usm = usm_;

--- a/contracts/FUM.sol
+++ b/contracts/FUM.sol
@@ -19,7 +19,7 @@ contract FUM is ERC20Permit, WithOptOut, Ownable {
     IUSM public immutable usm;
 
     constructor(IUSM usm_, address[] memory optedOut_)
-        ERC20Permit("Minimalist Funding v1.0", "FUM")
+        ERC20Permit("Minimalist Funding v1.0 - Test 3", "FUMTest")
         WithOptOut(optedOut_)
     {
         usm = usm_;

--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -28,5 +28,5 @@ abstract contract IUSM is IERC20 {
     function adjustedEthUsdPrice(Side side, uint ethUsdPrice, uint debtRatio_) public virtual pure returns (uint price);
     function usmPrice(Side side, uint adjustedEthUsdPrice_) public virtual pure returns (uint price);
     function fumPrice(Side side, uint adjustedEthUsdPrice_, uint ethInPool, uint usmEffectiveSupply, uint fumSupply) public virtual pure returns (uint price);
-    function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater, uint currentTime) public virtual pure returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys);
+    function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater, uint currentTime) public virtual pure returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys, uint debtRatio_);
 }

--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -25,7 +25,8 @@ abstract contract IUSM is IERC20 {
     function debtRatio(uint ethUsdPrice, uint ethInPool, uint usmSupply) public virtual pure returns (uint ratio);
     function ethToUsm(uint ethUsdPrice, uint ethAmount, WadMath.Round upOrDown) public virtual pure returns (uint usmOut);
     function usmToEth(uint ethUsdPrice, uint usmAmount, WadMath.Round upOrDown) public virtual pure returns (uint ethOut);
-    function usmPrice(Side side, uint ethUsdPrice, uint debtRatio_) public virtual pure returns (uint price);
-    function fumPrice(Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply, uint adjustment) public virtual pure returns (uint price);
+    function adjustedEthUsdPrice(Side side, uint ethUsdPrice, uint debtRatio_) public virtual pure returns (uint price);
+    function usmPrice(Side side, uint adjustedEthUsdPrice_) public virtual pure returns (uint price);
+    function fumPrice(Side side, uint adjustedEthUsdPrice_, uint ethInPool, uint usmEffectiveSupply, uint fumSupply) public virtual pure returns (uint price);
     function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater, uint currentTime) public virtual pure returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys);
 }

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.8.0;
  * the owner.
  */
 abstract contract Ownable {
-    address private _owner;
+    address public owner;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
@@ -24,35 +24,16 @@ abstract contract Ownable {
      * @dev Initializes the contract setting the deployer as the initial owner.
      */
     constructor () {
-        _owner = msg.sender;
+        owner = msg.sender;
         emit OwnershipTransferred(address(0), msg.sender);
-    }
-
-    /**
-     * @dev Returns the address of the current owner.
-     */
-    function owner() public view returns (address) {
-        return _owner;
     }
 
     /**
      * @dev Throws if called by any account other than the owner.
      */
     modifier onlyOwner() {
-        require(_owner == msg.sender, "Ownable: caller is not the owner");
+        require(owner == msg.sender, "Ownable: caller is not the owner");
         _;
-    }
-
-    /**
-     * @dev Leaves the contract without owner. It will not be possible to call
-     * `onlyOwner` functions anymore. Can only be called by the current owner.
-     *
-     * NOTE: Renouncing ownership will leave the contract without an owner,
-     * thereby removing any functionality that is only available to the owner.
-     */
-    function renounceOwnership() public virtual onlyOwner {
-        emit OwnershipTransferred(_owner, address(0));
-        _owner = address(0);
     }
 
     /**
@@ -60,8 +41,7 @@ abstract contract Ownable {
      * Can only be called by the current owner.
      */
     function transferOwnership(address newOwner) public virtual onlyOwner {
-        require(newOwner != address(0), "Ownable: new owner is the zero address");
-        emit OwnershipTransferred(_owner, newOwner);
-        _owner = newOwner;
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
     }
 }

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -60,7 +60,7 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
     });
 
     constructor(Oracle oracle_, address[] memory optedOut_)
-        ERC20Permit("Minimalist USD v1.0", "USM")
+        ERC20Permit("Minimalist USD v1.0 - Test 3", "USMTest")
         WithOptOut(optedOut_)
     {
         oracle = oracle_;

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -60,7 +60,7 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
     });
 
     constructor(Oracle oracle_, address[] memory optedOut_)
-        ERC20Permit("Minimalist USD v1.0 - Test 3", "USMTest")
+        ERC20Permit("Minimalist USD v1.0 - Test 4", "USMTest")
         WithOptOut(optedOut_)
     {
         oracle = oracle_;

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -603,15 +603,15 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
 
         // In theory, calculating the total amount of USM minted involves summing an integral over 1 / usmBuyPrice, which gives
         // the following simple logarithm:
-        int log = ethPool1.wadDivDown(ls.ethPool).wadLog();                     // 2a) Most exact: ~4k more gas
-        require(log >= 0, "log underflow");
-        //usmOut = ls.ethPool.wadDivDown(usmBuyPrice0).wadMulDown(uint(log));
-        usmOut = ls.ethPool * uint(log) / usmBuyPrice0;
+        //int log = ethPool1.wadDivDown(ls.ethPool).wadLog();                   // 2a) Most exact: ~4k more gas
+        //require(log >= 0, "log underflow");
+        ////usmOut = ls.ethPool.wadDivDown(usmBuyPrice0).wadMulDown(uint(log));
+        //usmOut = ls.ethPool * uint(log) / usmBuyPrice0;
 
         // But in practice, we can save some gas by approximating the log integral above as follows: take the geometric average
         // of the starting and ending usmBuyPrices, and just appply that average price to the entier ethIn passes in.
-        //uint usmBuyPriceAvg = usmBuyPrice0.wadDivUp(adjShrinkFactor);         // 2b) Approximate, but pretty close
-        //usmOut = ethIn.wadDivDown(usmBuyPriceAvg);
+        uint usmBuyPriceAvg = usmBuyPrice0.wadDivUp(adjShrinkFactor);           // 2b) Approximate, but pretty close
+        usmOut = ethIn.wadDivDown(usmBuyPriceAvg);
 
         //uint usmBuyPrice1 = usmBuyPrice0.wadDivUp(oneOverEthGrowthFactor);    // 2c) Even more approximate, & ~140 *more* gas
         //uint usmBuyPriceAvg = (usmBuyPrice0 + usmBuyPrice1) / 2;

--- a/contracts/USMView.sol
+++ b/contracts/USMView.sol
@@ -61,7 +61,8 @@ contract USMView {
      */
     function usmPrice(IUSM.Side side) external view returns (uint price) {
         (uint ethUsdPrice, ) = usm.latestPrice();
-        uint adjustedPrice = usm.adjustedEthUsdPrice(side, ethUsdPrice, usm.bidAskAdjustment());
+        IUSM.Side ethSide = (side == IUSM.Side.Buy ? IUSM.Side.Sell : IUSM.Side.Buy);   // Buying USM = selling ETH
+        uint adjustedPrice = usm.adjustedEthUsdPrice(ethSide, ethUsdPrice, usm.bidAskAdjustment());
         price = usm.usmPrice(side, adjustedPrice);
     }
 

--- a/contracts/USMView.sol
+++ b/contracts/USMView.sol
@@ -77,7 +77,7 @@ contract USMView {
         uint usmSupply = usm.totalSupply();
         uint oldTimeUnderwater = usm.timeSystemWentUnderwater();
         if (side == IUSM.Side.Buy) {
-            (, usmSupply) = usm.checkIfUnderwater(usmSupply, ethPool, ethUsdPrice, oldTimeUnderwater, block.timestamp);
+            (, usmSupply, ) = usm.checkIfUnderwater(usmSupply, ethPool, ethUsdPrice, oldTimeUnderwater, block.timestamp);
         }
         price = usm.fumPrice(side, adjustedPrice, ethPool, usmSupply, usm.fumTotalSupply());
     }

--- a/contracts/USMView.sol
+++ b/contracts/USMView.sol
@@ -61,7 +61,8 @@ contract USMView {
      */
     function usmPrice(IUSM.Side side) external view returns (uint price) {
         (uint ethUsdPrice, ) = usm.latestPrice();
-        price = usm.usmPrice(side, ethUsdPrice, usm.bidAskAdjustment());
+        uint adjustedPrice = usm.adjustedEthUsdPrice(side, ethUsdPrice, usm.bidAskAdjustment());
+        price = usm.usmPrice(side, adjustedPrice);
     }
 
     /**
@@ -70,12 +71,13 @@ contract USMView {
      */
     function fumPrice(IUSM.Side side) external view returns (uint price) {
         (uint ethUsdPrice, ) = usm.latestPrice();
+        uint adjustedPrice = usm.adjustedEthUsdPrice(side, ethUsdPrice, usm.bidAskAdjustment());
         uint ethPool = usm.ethPool();
         uint usmSupply = usm.totalSupply();
         uint oldTimeUnderwater = usm.timeSystemWentUnderwater();
         if (side == IUSM.Side.Buy) {
             (, usmSupply) = usm.checkIfUnderwater(usmSupply, ethPool, ethUsdPrice, oldTimeUnderwater, block.timestamp);
         }
-        price = usm.fumPrice(side, ethUsdPrice, ethPool, usmSupply, usm.fumTotalSupply(), usm.bidAskAdjustment());
+        price = usm.fumPrice(side, adjustedPrice, ethPool, usmSupply, usm.fumTotalSupply());
     }
 }

--- a/contracts/UsmWethProxy.sol
+++ b/contracts/UsmWethProxy.sol
@@ -5,10 +5,10 @@ import "./external/IWETH9.sol";
 import "./IUSM.sol";
 
 /**
- * @title USM Frontend Proxy
+ * @title USM Weth Frontend Proxy
  * @author Alberto Cuesta Cañada, Jacob Eliosoff, Alex Roan
  */
-contract Proxy {
+contract UsmWethProxy {
     IUSM public immutable usm;
     IWETH9 public immutable weth;
 
@@ -51,7 +51,7 @@ contract Proxy {
     {
         ethOut = usm.burn(msg.sender, payable(this), usmToBurn, minEthOut);
         weth.deposit{ value: ethOut }();
-        require(weth.transferFrom(address(this), to, ethOut), "WETH transfer fail");
+        require(weth.transfer(to, ethOut), "WETH transfer fail");
     }
 
     /**
@@ -80,6 +80,6 @@ contract Proxy {
     {
         ethOut = usm.defund(msg.sender, payable(this), fumToBurn, minEthOut);
         weth.deposit{ value: ethOut }();
-        require(weth.transferFrom(address(this), to, ethOut), "WETH transfer fail");
+        require(weth.transfer(to, ethOut), "WETH transfer fail");
     }
 }

--- a/contracts/WadMath.sol
+++ b/contracts/WadMath.sol
@@ -126,70 +126,12 @@ library WadMath {
         }
     }
 
-    /**
-     * @notice Babylonian method, from Uniswap:
-     * https://github.com/Uniswap/uniswap-v2-core/blob/v1.0.1/contracts/libraries/Math.sol (via
-     * https://ethereum.stackexchange.com/a/87713/64318).
-     */
-    function wadSqrtDownOld(uint y) internal pure returns (uint root) {
-        y *= WAD;
-        unchecked {
-            if (y > 3) {
-                root = y;
-                uint x = y / 2 + 1;
-                while (x < root) {
-                    root = x;
-                    x = (y / x + x) / 2;
-                }
-            } else if (y != 0) {
-                root = 1;
-            }
-        }
-    }
-
-    function wadSqrtUpOld(uint y) internal pure returns (uint root) {
-        root = wadSqrtDown(y);
-        // The only case where wadSqrtUp(y) *isn't* equal to wadSqrtDown(y) + 1 is when y is a perfect square; so check for that.
-        // These "*"s are safe because: 1. root**2 <= y * WAD, and 2. y * WAD is calculated (safely) above.
-        unchecked {
-            if (root * root != y * WAD ) {
-                ++root;
-            }
-        }
-        //require((root - 1)**2 < y * WAD && y * WAD <= root**2);
-    }
-
     function wadSqrtDown(uint y) internal pure returns (uint root) {
         root = wadPowDown(y, HALF_WAD);
     }
 
     function wadSqrtUp(uint y) internal pure returns (uint root) {
         root = wadPowUp(y, HALF_WAD);
-    }
-
-    /**
-     * @return z The (approximate!) natural logarithm of x, where both x and the return value are in WAD fixed-point form.
-     * @dev We're given X = x * 10**18 (WAD-formatted); we want to return Z = z * 10**18, where z =~ ln(x); and we have
-     * `log_2(x)` below, which returns Y = y * 2**121, where y =~ log2(x).  So the math we use is:
-     *
-     *     K1 = log2(10**18) * 2**121
-     *     K2 = log2(e) * 2**121 / 10**18
-     *     Z = (`log_2(X)` - K1) / K2
-     *       = (`log_2(x * 10**18)` - log2(10**18) * 2**121) / (log2(e) * 2**121 / 10**18)
-     *       = (log2(x * 10**18) * 2**121 - log2(10**18) * 2**121) / (log2(e) * 2**121 / 10**18)
-     *       = (log2(x * 10**18) - log2(10**18)) / (log2(e) / 10**18)
-     *       = (log2(x) / log2(e)) * 10**18
-     *       = ln(x) * 10**18
-     */
-    function wadLog(uint x) internal pure returns (int z) {
-        require(x <= type(uint128).max, "x overflow");
-        z = int(log_2(uint128(x)));
-        unchecked { z -= int(CEIL_LOG_2_WAD_SCALED); }
-        if (z >= 0) {   // Want to round z down, so if it's >= 0, divide by the const rounded up; if < 0, by const rounded down
-            unchecked { z /= int(CEIL_LOG_2_E_SCALED_OVER_WAD); }
-        } else {
-            unchecked { z /= int(FLOOR_LOG_2_E_SCALED_OVER_WAD); }
-        }
     }
 
     /**

--- a/contracts/WadMath.sol
+++ b/contracts/WadMath.sol
@@ -15,8 +15,10 @@ library WadMath {
     uint public constant WAD_OVER_10 = WAD / 10;
     uint public constant WAD_OVER_20 = WAD / 20;
     uint public constant HALF_TO_THE_ONE_TENTH = 933032991536807416;
-    uint public constant LOG_2_WAD_SCALED = 158961593653514369813532673448321674075;   // log_2(10**18) * 2**121
-    uint public constant LOG_2_E_SCALED_OVER_WAD = 3835341275459348170;                // log_2(e) * 2**121 / 10**18
+    uint public constant FLOOR_LOG_2_WAD_SCALED = 158961593653514369813532673448321674075;  // log_2(10**18) * 2**121
+    uint public constant  CEIL_LOG_2_WAD_SCALED = 158961593653514369813532673448321674076;  // log_2(10**18) * 2**121
+    uint public constant FLOOR_LOG_2_E_SCALED_OVER_WAD = 3835341275459348169;               // log_2(e) * 2**121 / 10**18
+    uint public constant  CEIL_LOG_2_E_SCALED_OVER_WAD = 3835341275459348170;               // log_2(e) * 2**121 / 10**18
 
     function wadMul(uint x, uint y, Round upOrDown) internal pure returns (uint z) {
         z = (upOrDown == Round.Down ? wadMulDown(x, y) : wadMulUp(x, y));
@@ -65,24 +67,26 @@ library WadMath {
     }
 
     /**
-     * @return exp Just returns `wadHalfExp(power, MAX_VALUE)`, ie, an approximation of 0.5**`power`, with `power` uncapped.
+     * @return exp Just returns `wadHalfExpApprox(power, MAX_VALUE)`, ie, an approximation of 0.5**`power`, with `power` uncapped.
      */
-    function wadHalfExp(uint power) internal pure returns (uint exp) {
-        exp = wadHalfExp(power, type(uint).max);
+    function wadHalfExpApprox(uint power) internal pure returns (uint exp) {
+        exp = wadHalfExpApprox(power, type(uint).max);
     }
 
     /**
+     * @notice Crudely approximates e**power.  Negative powers are not handled (as implied by power being a uint).
+     * @param power WAD-scaled (eg, 2.7364 * WAD)
+     * @param maxPower plain unscaled uint (eg, 10)
      * @return exp a loose but "gas-efficient" approximation of 0.5**power, where power is rounded to the nearest 0.1, and is
-     * capped at maxPower.  Note power is WAD-scaled (eg, 2.7364 * WAD), but maxPower is just a plain unscaled uint (eg, 10).
-     * Negative powers are not handled (as implied by power being a uint).
+     * capped at maxPower
      */
-    function wadHalfExp(uint power, uint maxPower) internal pure returns (uint exp) {
+    function wadHalfExpApprox(uint power, uint maxPower) internal pure returns (uint exp) {
         uint powerInTenthsUnscaled = power + WAD_OVER_20;       // Rounds 2.7499 -> 2.7, 2.7500 -> 2.8
         unchecked { powerInTenthsUnscaled /= WAD_OVER_10; }
         uint powerUnscaled;
         unchecked { powerUnscaled = powerInTenthsUnscaled / 10; }
         if (powerUnscaled <= maxPower) {    // If not, then 0.5**power is (more or less) tiny, so we just return exp = 0
-            exp = wadPow(HALF_TO_THE_ONE_TENTH, powerInTenthsUnscaled);
+            exp = wadPowApprox(HALF_TO_THE_ONE_TENTH, powerInTenthsUnscaled);
         }
     }
 
@@ -102,8 +106,11 @@ library WadMath {
      *   x^n = x * (x^2)^((n-1) / 2).
      *
      * Also, EVM division is flooring and floor[(n-1) / 2] = floor[n / 2].
+     * @param x base to raise to power n (x is WAD-scaled)
+     * @param n power to raise x to (n is *not* WAD-scaled - ie, passing n = 3 calculates x cubed)
+     * @return z x**n, WAD-scaled: so, since x and z are WAD-scaled and n isn't, z = (x / 10**18)**n * 10**18
      */
-    function wadPow(uint x, uint n) internal pure returns (uint z) {
+    function wadPowApprox(uint x, uint n) internal pure returns (uint z) {
         unchecked { z = n % 2 != 0 ? x : WAD; }
 
         unchecked { n /= 2; }
@@ -124,7 +131,7 @@ library WadMath {
      * https://github.com/Uniswap/uniswap-v2-core/blob/v1.0.1/contracts/libraries/Math.sol (via
      * https://ethereum.stackexchange.com/a/87713/64318).
      */
-    function wadSqrtDown(uint y) internal pure returns (uint root) {
+    function wadSqrtDownOld(uint y) internal pure returns (uint root) {
         y *= WAD;
         unchecked {
             if (y > 3) {
@@ -140,7 +147,7 @@ library WadMath {
         }
     }
 
-    function wadSqrtUp(uint y) internal pure returns (uint root) {
+    function wadSqrtUpOld(uint y) internal pure returns (uint root) {
         root = wadSqrtDown(y);
         // The only case where wadSqrtUp(y) *isn't* equal to wadSqrtDown(y) + 1 is when y is a perfect square; so check for that.
         // These "*"s are safe because: 1. root**2 <= y * WAD, and 2. y * WAD is calculated (safely) above.
@@ -152,12 +159,12 @@ library WadMath {
         //require((root - 1)**2 < y * WAD && y * WAD <= root**2);
     }
 
-    function wadSqrtApproxDown(uint y) internal pure returns (uint root) {
-        root = wadExp(y, HALF_WAD);
+    function wadSqrtDown(uint y) internal pure returns (uint root) {
+        root = wadPowDown(y, HALF_WAD);
     }
 
-    function wadSqrtApproxUp(uint y) internal pure returns (uint root) {
-        root = wadExp(y, HALF_WAD);
+    function wadSqrtUp(uint y) internal pure returns (uint root) {
+        root = wadPowUp(y, HALF_WAD);
     }
 
     /**
@@ -177,7 +184,12 @@ library WadMath {
     function wadLog(uint x) internal pure returns (int z) {
         require(x <= type(uint128).max, "x overflow");
         z = int(log_2(uint128(x)));
-        unchecked { z = (z - int(LOG_2_WAD_SCALED)) / int(LOG_2_E_SCALED_OVER_WAD); }
+        unchecked { z -= int(CEIL_LOG_2_WAD_SCALED); }
+        if (z >= 0) {   // Want to round z down, so if it's >= 0, divide by the const rounded up; if < 0, by const rounded down
+            unchecked { z /= int(CEIL_LOG_2_E_SCALED_OVER_WAD); }
+        } else {
+            unchecked { z /= int(FLOOR_LOG_2_E_SCALED_OVER_WAD); }
+        }
     }
 
     /**
@@ -186,7 +198,7 @@ library WadMath {
      * @notice This library works only on positive uint inputs.  If you have a negative exponent (y < 0), you can calculate it
      * using this identity:
      *
-     *     wadExp(y < 0) = 1 / wadExp(-y > 0) = WAD.div(wadExp(-y > 0))
+     *     wadExpDown(y < 0) = 1 / wadExp(-y > 0) = WAD.div(wadExp(-y > 0))
      *
      * @dev We're given Y = y * 10**18 (WAD-formatted); we want to return Z = z * 10**18, where z =~ e**y; and we have
      * `pow_2(X = x * 2**121)` below, which returns y =~ 2**x = 2**(X / 2**121).  So the math we use is:
@@ -201,10 +213,17 @@ library WadMath {
      *       = 10**18 * (2**log2(e))**y
      *       = e**y * 10**18
      */
-    function wadExp(uint y) internal pure returns (uint z) {
-        uint exponent = LOG_2_WAD_SCALED + LOG_2_E_SCALED_OVER_WAD * y;
+    function wadExpDown(uint y) internal pure returns (uint z) {
+        uint exponent = FLOOR_LOG_2_WAD_SCALED + FLOOR_LOG_2_E_SCALED_OVER_WAD * y;
         require(exponent <= type(uint128).max, "exponent overflow");
         z = pow_2(uint128(exponent));
+    }
+
+    function wadExpUp(uint y) internal pure returns (uint z) {
+        uint exponent = FLOOR_LOG_2_WAD_SCALED - CEIL_LOG_2_E_SCALED_OVER_WAD * y;
+        require(exponent <= type(uint128).max, "exponent overflow");
+        uint wadOneOverExpY = pow_2(uint128(exponent));
+        z = wadDivUp(WAD, wadOneOverExpY);
     }
 
     /**
@@ -213,8 +232,8 @@ library WadMath {
      * @notice This library works only on positive uint inputs.  If you have a negative base (x < 0) or a negative exponent
      * (y < 0), you can calculate them using these identities:
      *
-     *     wadExp(x < 0, y) = -wadExp(-x > 0, y)
-     *     wadExp(x, y < 0) = 1 / wadExp(x, -y > 0) = WAD.div(wadExp(x, -y > 0))
+     *     wadPowDown(x < 0, y) = -wadPowDown(-x > 0, y)
+     *     wadPowDown(x, y < 0) = 1 / wadPowUp(x, -y > 0) = WAD.div(wadPowUp(x, -y > 0))
      *
      * @dev We're given X = x * 10**18, and Y = y * 10**18 (both WAD-formatted); we want Z = z * 10**18, where z =~ x**y; and
      * we have `log_2(x)`, which returns log2(x) * 2**121, and `pow_2(X = x * 2**121)`, which returns 2**x = 2**(X / 2**121).
@@ -233,28 +252,32 @@ library WadMath {
      * Except, because we're working with unsigned numbers, we need to be careful to handle two cases separately:
      * log_2(X) >= K, and log_2(X) < K.
      */
-    function wadExp(uint x, uint y) internal pure returns (uint z) {
+    function wadPowDown(uint x, uint y) internal pure returns (uint z) {
         require(x <= type(uint128).max, "x overflow");
         uint logX = log_2(uint128(x));
         uint exponent;
-        if (logX >= LOG_2_WAD_SCALED) {
-            // Case 1: Z = pow_2(LOG_2_WAD_SCALED + (log_2(X) - LOG_2_WAD_SCALED) * Y / WAD):
-            unchecked { exponent = logX - LOG_2_WAD_SCALED; }
-            exponent = LOG_2_WAD_SCALED + wadMulDown(exponent, y);
+        if (logX >= CEIL_LOG_2_WAD_SCALED) {
+            // Case 1: Z = pow_2(FLOOR_LOG_2_WAD_SCALED + (log_2(X) - CEIL_LOG_2_WAD_SCALED) * Y / WAD):
+            unchecked { exponent = logX - CEIL_LOG_2_WAD_SCALED; }
+            exponent = FLOOR_LOG_2_WAD_SCALED + wadMulDown(exponent, y);
             require(exponent <= type(uint128).max, "exponent overflow");
             z = pow_2(uint128(exponent));
         } else {
-            // Case 2: Z = pow_2(LOG_2_WAD_SCALED - (LOG_2_WAD_SCALED - log_2(X)) * Y / WAD):
+            // Case 2: Z = pow_2(FLOOR_LOG_2_WAD_SCALED - (CEIL_LOG_2_WAD_SCALED - log_2(X)) * Y / WAD):
             uint exponentSubtrahend;
-            unchecked { exponentSubtrahend = LOG_2_WAD_SCALED - logX; }
-            exponentSubtrahend = wadMulDown(exponentSubtrahend, y);
-            if (exponentSubtrahend <= LOG_2_WAD_SCALED) {
-                unchecked { exponent = LOG_2_WAD_SCALED - exponentSubtrahend; }
-                z = pow_2(uint128(exponent));   // Needn't check for overflow since exp <= LOG_2_WAD_SCALED < type(uint128).max
+            unchecked { exponentSubtrahend = CEIL_LOG_2_WAD_SCALED - logX; }
+            exponentSubtrahend = wadMulUp(exponentSubtrahend, y);
+            if (exponentSubtrahend <= FLOOR_LOG_2_WAD_SCALED) {
+                unchecked { exponent = FLOOR_LOG_2_WAD_SCALED - exponentSubtrahend; }
+                z = pow_2(uint128(exponent));   // Needn't check overflow b/c exp <= FLOOR_LOG_2_WAD_SCALED < type(uint128).max
             } else {
                 // z = 0: exponent would be < 0, so pow_2(exponent) is vanishingly small (as a WAD-formatted num) - call it 0
             }
         }
+    }
+
+    function wadPowUp(uint x, uint y) internal pure returns (uint z) {
+        z = wadDivUp(WAD, wadPowDown(wadDivDown(WAD, x), y));
     }
 
     /* ____________________ Exponential/logarithm fns borrowed from Yield Protocol ____________________

--- a/contracts/mocks/MockWadMath.sol
+++ b/contracts/mocks/MockWadMath.sol
@@ -11,6 +11,14 @@ import "../WadMath.sol";
 contract MockWadMath {
     using WadMath for uint;
 
+    function wadSqrtUp(uint x) public pure returns (uint y) {
+        y = x.wadSqrtUp();
+    }
+
+    function wadSqrtDown(uint x) public pure returns (uint y) {
+        y = x.wadSqrtDown();
+    }
+
     function wadLog(uint x) public pure returns (int y) {
         y = x.wadLog();
     }

--- a/contracts/mocks/MockWadMath.sol
+++ b/contracts/mocks/MockWadMath.sol
@@ -19,10 +19,6 @@ contract MockWadMath {
         y = x.wadSqrtDown();
     }
 
-    function wadLog(uint x) public pure returns (int y) {
-        y = x.wadLog();
-    }
-
     function wadExpDown(uint y) public pure returns (uint z) {
         z = y.wadExpDown();
     }

--- a/contracts/mocks/MockWadMath.sol
+++ b/contracts/mocks/MockWadMath.sol
@@ -23,11 +23,19 @@ contract MockWadMath {
         y = x.wadLog();
     }
 
-    function wadExp(uint y) public pure returns (uint z) {
-        z = y.wadExp();
+    function wadExpDown(uint y) public pure returns (uint z) {
+        z = y.wadExpDown();
     }
 
-    function wadExp(uint x, uint y) public pure returns (uint z) {
-        z = x.wadExp(y);
+    function wadExpUp(uint y) public pure returns (uint z) {
+        z = y.wadExpUp();
+    }
+
+    function wadPowDown(uint x, uint y) public pure returns (uint z) {
+        z = x.wadPowDown(y);
+    }
+
+    function wadPowUp(uint x, uint y) public pure returns (uint z) {
+        z = x.wadPowUp(y);
     }
 }

--- a/contracts/oracles/MedianOracle.sol
+++ b/contracts/oracles/MedianOracle.sol
@@ -5,6 +5,12 @@ import "./ChainlinkOracle.sol";
 import "./CompoundOpenOracle.sol";
 import "./OurUniswapV2TWAPOracle.sol";
 
+/**
+ * We make MedianOracle *inherit* its median-component oracles (eg, ChainlinkOracle), rather than hold them as state variables
+ * like any sane person would, because this significantly reduces the number of (gas-pricey) external contract calls.
+ * Eg, this contract calling ChainlinkOracle.latestPrice() on itself is significantly cheaper than calling
+ * chainlinkOracle.latestPrice() on a chainlinkOracle var (contract).
+ */
 contract MedianOracle is ChainlinkOracle, CompoundOpenOracle, OurUniswapV2TWAPOracle {
 
     constructor(

--- a/deploy/4_deploy_usmwethproxy.js
+++ b/deploy/4_deploy_usmwethproxy.js
@@ -24,14 +24,14 @@ const func = async function ({ deployments, getNamedAccounts, getChainId }) {
 
   usmAddress = (await get('USM')).address;
 
-  const proxy = await deploy('Proxy', {
+  const proxy = await deploy('UsmWethProxy', {
     from: deployer,
     deterministicDeployment: true,
     args: [usmAddress, wethAddress]
   })
 
-  console.log(`Deployed Proxy to ${proxy.address}`);
+  console.log(`Deployed UsmWethProxy to ${proxy.address}`);
 }
 
 module.exports = func;
-module.exports.tags = ["Proxy"];
+module.exports.tags = ["UsmWethProxy"];

--- a/deploy/fum-args-42.js
+++ b/deploy/fum-args-42.js
@@ -1,12 +1,14 @@
 // Used for contract verification on Etherscan
 const addresses = {
-    'usm': '0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67',
+    'usm': '0x7dbC406E09c876C77949A45BBE4173Aa6CdF9470',
     'USMv0.1': '0x21453979384f21D09534f8801467BDd5d90eCD6C',
     'FUMv0.1': '0x96F8F5323Aa6CB0e6F311bdE6DEEFb1c81Cb1898',
     'USMv0.2-rc1': '0xf05627D4F72bC4778BAECcbeaCa44b013e9b8227',
     'FUMv0.2-rc1': '0xe13b57555e5a538785130fda6e918185b9fe1599',
     'USMv0.2': '0x6dcc375aE1f43c8FA4e13D56E6ec584BeE25A88F',
     'FUMv0.2': '0xf99b440d8e18f850187ae53cdd4ebc959ebf36df',
+    'USMv0.3': '0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67',
+    'FUMv0.3': '0x0f682f36363b4cd5261dd613f4caec6e6c8a5eef',
 }
   
 module.exports = [
@@ -18,5 +20,7 @@ module.exports = [
         addresses['FUMv0.2-rc1'],
         addresses['USMv0.2'],
         addresses['FUMv0.2'],
+        addresses['USMv0.3'],
+        addresses['FUMv0.3'],
     ],
 ];

--- a/deploy/fum-args-42.js
+++ b/deploy/fum-args-42.js
@@ -1,10 +1,12 @@
 // Used for contract verification on Etherscan
 const addresses = {
-    'usm': '0x6dcc375aE1f43c8FA4e13D56E6ec584BeE25A88F',
+    'usm': '0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67',
     'USMv0.1': '0x21453979384f21D09534f8801467BDd5d90eCD6C',
     'FUMv0.1': '0x96F8F5323Aa6CB0e6F311bdE6DEEFb1c81Cb1898',
-    'USMv0.2': '0xf05627D4F72bC4778BAECcbeaCa44b013e9b8227',
-    'FUMv0.2': '0xe13b57555e5a538785130fda6e918185b9fe1599',
+    'USMv0.2-rc1': '0xf05627D4F72bC4778BAECcbeaCa44b013e9b8227',
+    'FUMv0.2-rc1': '0xe13b57555e5a538785130fda6e918185b9fe1599',
+    'USMv0.2': '0x6dcc375aE1f43c8FA4e13D56E6ec584BeE25A88F',
+    'FUMv0.2': '0xf99b440d8e18f850187ae53cdd4ebc959ebf36df',
 }
   
 module.exports = [
@@ -12,6 +14,8 @@ module.exports = [
     [
         addresses['USMv0.1'],
         addresses['FUMv0.1'],
+        addresses['USMv0.2-rc1'],
+        addresses['FUMv0.2-rc1'],
         addresses['USMv0.2'],
         addresses['FUMv0.2'],
     ],

--- a/deploy/usm-args-42.js
+++ b/deploy/usm-args-42.js
@@ -6,6 +6,8 @@ const addresses = {
     'FUMv0.2-rc1': '0xe13b57555e5a538785130fda6e918185b9fe1599',
     'USMv0.2': '0x6dcc375aE1f43c8FA4e13D56E6ec584BeE25A88F',
     'FUMv0.2': '0xf99b440d8e18f850187ae53cdd4ebc959ebf36df',
+    'USMv0.3': '0x19b490DAA2B58d9B12BFb15Cd3eFC2358ad2Bd67',
+    'FUMv0.3': '0x0f682f36363b4cd5261dd613f4caec6e6c8a5eef',
 }
   
 module.exports = [
@@ -17,5 +19,7 @@ module.exports = [
         addresses['FUMv0.2-rc1'],
         addresses['USMv0.2'],
         addresses['FUMv0.2'],
+        addresses['USMv0.3'],
+        addresses['FUMv0.3'],
     ],
 ];

--- a/deploy/usm-args-42.js
+++ b/deploy/usm-args-42.js
@@ -1,9 +1,11 @@
 const addresses = {
-    'oracle': '0x7525D619F2A01aea8ADc92cDD06152b25267c765',
+    'oracle': '0x8e91D25324833D62Fb3eC67aDEE26048696c8909',
     'USMv0.1': '0x21453979384f21D09534f8801467BDd5d90eCD6C',
     'FUMv0.1': '0x96F8F5323Aa6CB0e6F311bdE6DEEFb1c81Cb1898',
-    'USMv0.2': '0xf05627D4F72bC4778BAECcbeaCa44b013e9b8227',
-    'FUMv0.2': '0xe13b57555e5a538785130fda6e918185b9fe1599',
+    'USMv0.2-rc1': '0xf05627D4F72bC4778BAECcbeaCa44b013e9b8227',
+    'FUMv0.2-rc1': '0xe13b57555e5a538785130fda6e918185b9fe1599',
+    'USMv0.2': '0x6dcc375aE1f43c8FA4e13D56E6ec584BeE25A88F',
+    'FUMv0.2': '0xf99b440d8e18f850187ae53cdd4ebc959ebf36df',
 }
   
 module.exports = [
@@ -11,6 +13,8 @@ module.exports = [
     [
         addresses['USMv0.1'],
         addresses['FUMv0.1'],
+        addresses['USMv0.2-rc1'],
+        addresses['FUMv0.2-rc1'],
         addresses['USMv0.2'],
         addresses['FUMv0.2'],
     ],

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -66,7 +66,8 @@ module.exports = {
     },
     mainnet: {
       accounts,
-      url: nodeUrl('mainnet')
+      url: nodeUrl('mainnet'),
+      gasPrice: 150000000000
     },
     coverage: {
       url: 'http://127.0.0.1:8555',

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -297,13 +297,6 @@ contract('USM', (accounts) => {
             const a = new BN('987654321098765432')    //  0.987654321098765432
             const b = new BN('12345678901234567890')  // 12.345678901234567890
 
-            const logA = await w.wadLog(a)
-            const targetLogA = wad(Math.log(fl(a)))
-            shouldEqualApprox(logA, targetLogA)
-            const logB = await w.wadLog(b)
-            const targetLogB = wad(Math.log(fl(b)))
-            shouldEqualApprox(logB, targetLogB)
-
             const expDownA = await w.wadExpDown(a)
             const expUpA = await w.wadExpUp(a)
             const targetExpA = wad(Math.exp(fl(a)))

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -304,19 +304,27 @@ contract('USM', (accounts) => {
             const targetLogB = wad(Math.log(fl(b)))
             shouldEqualApprox(logB, targetLogB)
 
-            const expA = await w.wadExp(a)
+            const expDownA = await w.wadExpDown(a)
+            const expUpA = await w.wadExpUp(a)
             const targetExpA = wad(Math.exp(fl(a)))
-            shouldEqualApprox(expA, targetExpA)
-            const expB = await w.wadExp(b)
+            shouldEqualApprox(expDownA, targetExpA)
+            shouldEqualApprox(expUpA, targetExpA)
+            const expDownB = await w.wadExpDown(b)
+            const expUpB = await w.wadExpUp(b)
             const targetExpB = wad(Math.exp(fl(b)))
-            shouldEqualApprox(expB, targetExpB)
+            shouldEqualApprox(expDownB, targetExpB)
+            shouldEqualApprox(expUpB, targetExpB)
 
-            const expAB = await w.wadExp(a, b)
+            const expDownAB = await w.wadPowDown(a, b)
+            const expUpAB = await w.wadPowUp(a, b)
             const targetExpAB = wad(fl(a)**fl(b))
-            shouldEqualApprox(expAB, targetExpAB)
-            const expBA = await w.wadExp(b, a)
+            shouldEqualApprox(expDownAB, targetExpAB)
+            shouldEqualApprox(expUpAB, targetExpAB)
+            const expDownBA = await w.wadPowDown(b, a)
+            const expUpBA = await w.wadPowUp(b, a)
             const targetExpBA = wad(fl(b)**fl(a))
-            shouldEqualApprox(expBA, targetExpBA)
+            shouldEqualApprox(expDownBA, targetExpBA)
+            shouldEqualApprox(expUpBA, targetExpBA)
           })
 
           it("allows minting FUM (at sliding price)", async () => {
@@ -355,17 +363,17 @@ contract('USM', (accounts) => {
                 r = (new BN(roots[i])).mul(WAD)
                 square = wadSquared(r)
                 sqrt = await w.wadSqrtDown(square)
-                shouldEqual(sqrt, r)            // wadSqrtDown(49000000000000000000) should return 7000000000000000000
+                sqrt.should.be.bignumber.lte(r) // wadSqrtDown(49000000000000000000) should return <= 7000000000000000000
                 sqrt = await w.wadSqrtUp(square)
-                shouldEqual(sqrt, r)            // wadSqrtUp(49000000000000000000) should return 7000000000000000000
+                sqrt.should.be.bignumber.gte(r) // wadSqrtUp(49000000000000000000) should return >= 7000000000000000000
                 sqrt = await w.wadSqrtDown(square.add(ONE))
-                shouldEqual(sqrt, r)            // wadSqrtDown(49000000000000000001) should return 7000000000000000000 too
+                sqrt.should.be.bignumber.lte(r) // wadSqrtDown(49000000000000000001) should return <= 7000000000000000000 too
                 sqrt = await w.wadSqrtUp(square.add(ONE))
-                shouldEqual(sqrt, r.add(ONE))   // wadSqrtUp(49000000000000000001) should return 7000000000000000001 (ie, round up)
+                sqrt.should.be.bignumber.gt(r)  // wadSqrtUp(49000000000000000001) should return *>* 7000000000000000000 (ie, round up)
                 sqrt = await w.wadSqrtDown(square.sub(ONE))
-                shouldEqual(sqrt, r.sub(ONE))   // wadSqrtDown(48999999999999999999) should return 6999999999999999999 (ie, round down)
+                sqrt.should.be.bignumber.lt(r)  // wadSqrtDown(48999999999999999999) should return *<* 6999999999999999999 (ie, round down)
                 sqrt = await w.wadSqrtUp(square.sub(ONE))
-                shouldEqual(sqrt, r)            // wadSqrtUp(48999999999999999999) should return 7000000000000000000 (ie, round up)
+                sqrt.should.be.bignumber.gte(r) // wadSqrtUp(48999999999999999999) should return >= 7000000000000000000 (ie, round up)
               }
             })
 

--- a/test/04_Proxy_Eth.test.js
+++ b/test/04_Proxy_Eth.test.js
@@ -111,12 +111,12 @@ contract('USM - Proxy - Eth', (accounts) => {
           })
 
           it('allows minting USM by sending ETH, if minUsmOut specified but met (2)', async () => {
-            await web3.eth.sendTransaction({ from: user1, to: usm.address, value: '1000000000000010136' }) // Returns >= 101.36 USM per ETH
+            await web3.eth.sendTransaction({ from: user1, to: usm.address, value: '1000000000000010206' }) // Returns >= 102.06 USM per ETH
           })
 
           it('does not mint USM by sending ETH, if minUsmOut specified and missed (1)', async () => {
             await expectRevert(
-              web3.eth.sendTransaction({ from: user1, to: usm.address, value: '1000000000000010137' }), // Returns < 101.37 USM per ETH
+              web3.eth.sendTransaction({ from: user1, to: usm.address, value: '1000000000000010207' }), // Returns < 102.07 USM per ETH
               "Limit not reached",
             )
           })
@@ -155,7 +155,7 @@ contract('USM - Proxy - Eth', (accounts) => {
             const startingEthPool = await usm.ethPool()
             const startingWethBalance = await weth.balanceOf(user1)
 
-            const fumToBurn = startingFumBalance.mul(new BN('3')).div(new BN('4')) // defund 75% of our FUM
+            const fumToBurn = startingFumBalance.div(new BN('2')) // defund 50% of our FUM
             await proxy.defund(user1, fumToBurn, 0, { from: user1 })
 
             const endingFumBalance = await fum.balanceOf(user1)


### PR DESCRIPTION
Three broad changes here, split out into ten commits:

1. Refinements to the fee math in `usmFromMint()`, `ethFromBurn()`, `fumFromFund()` and `ethFromDefund()`, making all four follow the same coherent approach:

   1. Figure out the `adjChangeFactor` by which to scale both a) the system's ETH/USD mid price (which the adjusted buy/sell price will revert back to in a few minutes), and b) the `bidAskAdjustment` temporarily padded on to the mid.  (We always scale both of these by the same factor.)
   2. Using that `adjChangeFactor`, calculate/estimate the buy/sell price (eg, USM buy price for `mint()`, FUM sell price for `defund()`, etc) the operation will _end_ at.  (It's always easy to calculate the buy/sell price the operation _started_ at.)
   3. Using those starting and ending buy/sell prices, calculate/estimate the output - the `usmOut`, `fumOut` or `ethOut` returned to the user.  The choice of formulas here comes down to a mix of correct incentives (higher % fees for larger operations), simplicity and gas-efficiency:
      - For `burn()`, we can cheaply calculate the relevant integral exactly.
      - For the other three, we use approximations that average the starting and ending buy/sell prices to give an avg buy/sell price, and then simply divide/multiply that avg buy/sell price by the input ETH/USM/FUM amount.

2. A related change: now every buy or sell price is calculated from a single ETH/USD price: the `adjustedEthUsdPrice`, ie, the mid ETH/USD price scaled by the `bidAskAdjustment` if appropriate.  Previously, buy/sell prices were calculated using a mix of the adjusted ETH/USD price and the mid ETH/USD price: I think this was unnecessarily complicated.

3. Split `wadExp(x)`/`wadPow(x, y)` into `wadExpDown()`/`wadExpUp()` and `wadPowDown()`/`wadPowUp()`, to ensure rounding is always against the user.  (These new versions aren't yet heavily tested.  Also this finicky rounding may be overkill anyway - not clear whether it's worth the code complexity.)