### PR TITLE
Move (non-implementation-specific) comments from USM to IUSM.  (Maybe?)

### DIFF
--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -77,8 +77,8 @@ abstract contract IUSM is IERC20 {
 
     /**
      * @notice Total amount of ETH in the pool (ie, in the contract).
-     * @return supply the total supply of FUM.  We can't call `usm.fum().totalSupply()` directly because this `IUSM` interface
-     * doesn't (and shouldn't) know about the `FUM` type.
+     * @return supply the total supply of FUM.  Users of this `IUSM` interface, like `USMView`, need to call this rather than
+     * `usm.fum().totalSupply()` directly, because `IUSM` doesn't (and shouldn't) know about the `FUM` type.
      */
     function fumTotalSupply() public virtual view returns (uint supply);
 

--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -11,31 +11,156 @@ abstract contract IUSM is IERC20 {
 
     enum Side {Buy, Sell}
 
+    // ____________________ External transactional functions ____________________
+
+    /**
+     * @notice Mint new USM, sending it to the given address, and only if the amount minted >= `minUsmOut`.  The amount of ETH
+     * is passed in as `msg.value`.
+     * @param to address to send the USM to.
+     * @param minUsmOut Minimum accepted USM for a successful mint.
+     */
     function mint(address to, uint minUsmOut) external virtual payable returns (uint);
+
+    /**
+     * @dev Burn USM in exchange for ETH.
+     * @param from address to deduct the USM from.
+     * @param to address to send the ETH to.
+     * @param usmToBurn Amount of USM to burn.
+     * @param minEthOut Minimum accepted ETH for a successful burn.
+     */
     function burn(address from, address payable to, uint usmToBurn, uint minEthOut) external virtual returns (uint);
+
+    /**
+     * @notice Funds the pool with ETH, minting new FUM and sending it to the given address, but only if the amount minted >=
+     * `minFumOut`.  The amount of ETH is passed in as `msg.value`.
+     * @param to address to send the FUM to.
+     * @param minFumOut Minimum accepted FUM for a successful fund.
+     */
     function fund(address to, uint minFumOut) external virtual payable returns (uint);
+
+    /**
+     * @notice Defunds the pool by redeeming FUM in exchange for equivalent ETH from the pool.
+     * @param from address to deduct the FUM from.
+     * @param to address to send the ETH to.
+     * @param fumToBurn Amount of FUM to burn.
+     * @param minEthOut Minimum accepted ETH for a successful defund.
+     */
     function defund(address from, address payable to, uint fumToBurn, uint minEthOut) external virtual returns (uint);
+
+    // ____________________ Public transactional functions ____________________
 
     function refreshPrice() public virtual returns (uint price, uint updateTime);
 
+    // ____________________ Public Oracle view functions ____________________
+
     /**
-     * latestOraclePrice() just returns the last ETH/USD price update we received from the oracle.  latestPrice() returns the
-     * USM system's latest internal (mid) ETH/USD price, which may have been pushed up (by long-ETH operations, ie, burn() or
-     * fund()) or down (by short-ETH operations, mint() or defund()) since the last oracle update.
+     * @return price the USM system's latest internal (mid) ETH/USD price, which may have been pushed up (by long-ETH
+     * operations, ie, burn() or fund()) or down (by short-ETH operations, mint() or defund()) since the last oracle update.
+     * @return updateTime the time as of which the price was updated.  This is not as simple as "the last time the returned
+     * price changed"; see the comment in `OurUniswapV2TWAPOracle._latestPrice()`.
+     */
+    function latestPrice() public virtual view returns (uint price, uint updateTime);
+
+    // ____________________ Public informational view functions ____________________
+
+    /**
+     * @return price the last ETH/USD price update we received from the oracle.
+     * @return updateTime time the price was updated - again, not trivial, see `OurUniswapV2TWAPOracle._latestPrice()`.
      */
     function latestOraclePrice() public virtual view returns (uint price, uint updateTime);
-    function latestPrice() public virtual view returns (uint price, uint updateTime);
+
+    /**
+     * @notice Total amount of ETH in the pool (ie, in the contract).
+     * @return pool ETH pool
+     */
     function ethPool() public virtual view returns (uint pool);
+
+    /**
+     * @notice Total amount of ETH in the pool (ie, in the contract).
+     * @return supply the total supply of FUM.  We can't call `usm.fum().totalSupply()` directly because this `IUSM` interface
+     * doesn't (and shouldn't) know about the `FUM` type.
+     */
     function fumTotalSupply() public virtual view returns (uint supply);
+
+    /**
+     * @notice The current bid/ask adjustment, equal to the stored value decayed over time towards its stable value, 1.  This
+     * adjustment is intended as a measure of "how long-ETH recent user activity has been", so that we can slide price
+     * accordingly: if recent activity was mostly long-ETH (`fund()` and `burn()`), raise FUM buy price/reduce USM sell price;
+     * if recent activity was short-ETH (`defund()` and `mint()`), reduce FUM sell price/raise USM buy price.
+     * @return adjustment The sliding-price bid/ask adjustment
+     */
     function bidAskAdjustment() public virtual view returns (uint adjustment);
+
     function timeSystemWentUnderwater() public virtual view returns (uint timestamp);
 
+    // ____________________ Public helper pure functions (for functions above) ____________________
+
+    /**
+     * @notice Calculate the amount of ETH in the buffer.
+     * @return buffer ETH buffer
+     */
     function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, WadMath.Round upOrDown) public virtual pure returns (int buffer);
+
+    /**
+     * @notice Calculate debt ratio for a given eth to USM price: ratio of the outstanding USM (amount of USM in total supply),
+     * to the current ETH pool value in USD (ETH qty * ETH/USD price).
+     * @return ratio Debt ratio (or 0 if there's currently 0 ETH in the pool/price = 0: these should never happen after launch)
+     */
     function debtRatio(uint ethUsdPrice, uint ethInPool, uint usmSupply) public virtual pure returns (uint ratio);
+
+    /**
+     * @notice Convert ETH amount to USM using a ETH/USD price.
+     * @param ethAmount The amount of ETH to convert
+     * @return usmOut The amount of USM
+     */
     function ethToUsm(uint ethUsdPrice, uint ethAmount, WadMath.Round upOrDown) public virtual pure returns (uint usmOut);
+
+    /**
+     * @notice Convert USM amount to ETH using a ETH/USD price.
+     * @param usmAmount The amount of USM to convert
+     * @return ethOut The amount of ETH
+     */
     function usmToEth(uint ethUsdPrice, uint usmAmount, WadMath.Round upOrDown) public virtual pure returns (uint ethOut);
+
+    /**
+     * @return price The ETH/USD price, adjusted by the `bidAskAdjustment` (if applicable) for the given buy/sell side.
+     */
     function adjustedEthUsdPrice(Side side, uint ethUsdPrice, uint debtRatio_) public virtual pure returns (uint price);
+
+    /**
+     * @notice Calculate the *marginal* price of USM (in ETH terms): that is, of the next unit, before the price start sliding.
+     * @return price USM price in ETH terms
+     */
     function usmPrice(Side side, uint adjustedEthUsdPrice_) public virtual pure returns (uint price);
+
+    /**
+     * @notice Calculate the *marginal* price of FUM (in ETH terms): that is, of the next unit, before the price starts rising.
+     * @param usmEffectiveSupply should be either the actual current USM supply, or, when calculating the FUM *buy* price, the
+     * return value of `usmSupplyForFumBuys()`.
+     * @return price FUM price in ETH terms
+     */
     function fumPrice(Side side, uint adjustedEthUsdPrice_, uint ethInPool, uint usmEffectiveSupply, uint fumSupply) public virtual pure returns (uint price);
+
+    /**
+     * @return timeSystemWentUnderwater_ The time at which we first detected the system was underwater (debt ratio >
+     * `MAX_DEBT_RATIO`), based on the current oracle price and pool ETH and USM; or 0 if we're not currently underwater.
+     * @return usmSupplyForFumBuys The current supply of USM *for purposes of calculating the FUM buy price,* and therefore
+     * for `fumFromFund()`.  The "supply for FUM buys" is the *lesser* of the actual current USM supply, and the USM amount
+     * that would make debt ratio = `MAX_DEBT_RATIO`.  Example:
+     *
+     * 1. Suppose the system currently contains 50 ETH at price $1,000 (total pool value: $50,000), with an actual USM supply
+     *    of 30,000 USM.  Then debt ratio = 30,000 / $50,000 = 60%: < MAX 80%, so `usmSupplyForFumBuys` = 30,000.
+     * 2. Now suppose ETH/USD halves to $500.  Then pool value halves to $25,000, and debt ratio doubles to 120%.  Now
+     *    `usmSupplyForFumBuys` instead = 20,000: the USM quantity at which debt ratio would equal 80% (20,000 / $25,000).
+     *    (Call this the "80% supply".)
+     * 3. ...Except, we also gradually increase the supply over time while we remain underwater.  This has the effect of
+     *    *reducing* the FUM buy price inferred from that supply (higher JacobUSM supply -> smaller buffer -> lower FUM price).
+     *    The math we use gradually increases the supply from its initial "80% supply" value, where debt ratio =
+     *    `MAX_DEBT_RATIO` (20,000 above), to a theoretical maximum "100% supply" value, where debt ratio = 100% (in the $500
+     *    example above, this would be 25,000).  (Or the actual supply, whichever is lower: we never increase
+     *    `usmSupplyForFumBuys` above `usmActualSupply`.)  The climb from the initial 80% supply (20,000) to the 100% supply
+     *    (25,000) is at a rate that brings it "halfway closer per `MIN_FUM_BUY_PRICE_HALF_LIFE` (eg, 1 day)": so three days
+     *    after going underwater, the supply returned will be 25,000 - 0.5**3 * (25,000 - 20,000) = 24,375.
+     */
     function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater, uint currentTime) public virtual pure returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys, uint debtRatio_);
 }

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -78,10 +78,23 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
 
     // ____________________ External transactional functions ____________________
 
+    /**
+     * @notice Mint new USM, sending it to the given address, and only if the amount minted >= `minUsmOut`.  The amount of ETH
+     * is passed in as `msg.value`.
+     * @param to address to send the USM to.
+     * @param minUsmOut Minimum accepted USM for a successful mint.
+     */
     function mint(address to, uint minUsmOut) external payable override returns (uint usmOut) {
         usmOut = _mintUsm(to, minUsmOut);
     }
 
+    /**
+     * @dev Burn USM in exchange for ETH.
+     * @param from address to deduct the USM from.
+     * @param to address to send the ETH to.
+     * @param usmToBurn Amount of USM to burn.
+     * @param minEthOut Minimum accepted ETH for a successful burn.
+     */
     function burn(address from, address payable to, uint usmToBurn, uint minEthOut)
         external override
         onlyHolderOrDelegate(from, "Only holder or delegate")
@@ -90,10 +103,23 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         ethOut = _burnUsm(from, to, usmToBurn, minEthOut);
     }
 
+    /**
+     * @notice Funds the pool with ETH, minting new FUM and sending it to the given address, but only if the amount minted >=
+     * `minFumOut`.  The amount of ETH is passed in as `msg.value`.
+     * @param to address to send the FUM to.
+     * @param minFumOut Minimum accepted FUM for a successful fund.
+     */
     function fund(address to, uint minFumOut) external payable override returns (uint fumOut) {
         fumOut = _fundFum(to, minFumOut);
     }
 
+    /**
+     * @notice Defunds the pool by redeeming FUM in exchange for equivalent ETH from the pool.
+     * @param from address to deduct the FUM from.
+     * @param to address to send the ETH to.
+     * @param fumToBurn Amount of FUM to burn.
+     * @param minEthOut Minimum accepted ETH for a successful defund.
+     */
     function defund(address from, address payable to, uint fumToBurn, uint minEthOut)
         external override
         onlyHolderOrDelegateOrFUM(from, "Only holder or delegate or FUM")
@@ -361,6 +387,10 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         (price, updateTime) = oracle.latestPrice();
     }
 
+    /**
+     * @notice Total amount of ETH in the pool (ie, in the contract).
+     * @return pool ETH pool
+     */
     function ethPool() public override view returns (uint pool) {
         pool = address(this).balance;
     }
@@ -369,6 +399,13 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         supply = fum.totalSupply();
     }
 
+    /**
+     * @notice The current bid/ask adjustment, equal to the stored value decayed over time towards its stable value, 1.  This
+     * adjustment is intended as a measure of "how long-ETH recent user activity has been", so that we can slide price
+     * accordingly: if recent activity was mostly long-ETH (`fund()` and `burn()`), raise FUM buy price/reduce USM sell price;
+     * if recent activity was short-ETH (`defund()` and `mint()`), reduce FUM sell price/raise USM buy price.
+     * @return adjustment The sliding-price bid/ask adjustment
+     */
     function bidAskAdjustment() public override view returns (uint adjustment) {
         adjustment = loadState().bidAskAdjustment;      // Not just from storedState, b/c need to update it - see loadState()
     }
@@ -396,6 +433,10 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
 
     // ____________________ Public helper pure functions (for functions above) ____________________
 
+    /**
+     * @notice Calculate the amount of ETH in the buffer.
+     * @return buffer ETH buffer
+     */
     function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, WadMath.Round upOrDown)
         public override pure returns (int buffer)
     {
@@ -406,19 +447,37 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         buffer = int(ethInPool) - int(usmValueInEth);   // After the previous line, no over/underflow should be possible here
     }
 
+    /**
+     * @notice Calculate debt ratio for a given eth to USM price: ratio of the outstanding USM (amount of USM in total supply),
+     * to the current ETH pool value in USD (ETH qty * ETH/USD price).
+     * @return ratio Debt ratio (or 0 if there's currently 0 ETH in the pool/price = 0: these should never happen after launch)
+     */
     function debtRatio(uint ethUsdPrice, uint ethInPool, uint usmSupply) public override pure returns (uint ratio) {
         uint ethPoolValueInUsd = ethInPool.wadMulDown(ethUsdPrice);
         ratio = (ethPoolValueInUsd == 0 ? 0 : usmSupply.wadDivUp(ethPoolValueInUsd));
     }
 
+    /**
+     * @notice Convert ETH amount to USM using a ETH/USD price.
+     * @param ethAmount The amount of ETH to convert
+     * @return usmOut The amount of USM
+     */
     function ethToUsm(uint ethUsdPrice, uint ethAmount, WadMath.Round upOrDown) public override pure returns (uint usmOut) {
         usmOut = ethAmount.wadMul(ethUsdPrice, upOrDown);
     }
 
+    /**
+     * @notice Convert USM amount to ETH using a ETH/USD price.
+     * @param usmAmount The amount of USM to convert
+     * @return ethOut The amount of ETH
+     */
     function usmToEth(uint ethUsdPrice, uint usmAmount, WadMath.Round upOrDown) public override pure returns (uint ethOut) {
         ethOut = usmAmount.wadDiv(ethUsdPrice, upOrDown);
     }
 
+    /**
+     * @return price The ETH/USD price, adjusted by the `bidAskAdjustment` (if applicable) for the given buy/sell side.
+     */
     function adjustedEthUsdPrice(IUSM.Side side, uint ethUsdPrice, uint adjustment) public override pure returns (uint price) {
         price = ethUsdPrice;
 
@@ -429,11 +488,21 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         }
     }
 
+    /**
+     * @notice Calculate the *marginal* price of USM (in ETH terms): that is, of the next unit, before the price start sliding.
+     * @return price USM price in ETH terms
+     */
     function usmPrice(IUSM.Side side, uint ethUsdPrice) public override pure returns (uint price) {
         WadMath.Round upOrDown = (side == IUSM.Side.Buy ? WadMath.Round.Up : WadMath.Round.Down);
         price = usmToEth(ethUsdPrice, WAD, upOrDown);
     }
 
+    /**
+     * @notice Calculate the *marginal* price of FUM (in ETH terms): that is, of the next unit, before the price starts rising.
+     * @param usmEffectiveSupply should be either the actual current USM supply, or, when calculating the FUM *buy* price, the
+     * return value of `usmSupplyForFumBuys()`.
+     * @return price FUM price in ETH terms
+     */
     function fumPrice(IUSM.Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply)
         public override pure returns (uint price)
     {
@@ -448,6 +517,27 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         }
     }
 
+    /**
+     * @return timeSystemWentUnderwater_ The time at which we first detected the system was underwater (debt ratio >
+     * `MAX_DEBT_RATIO`), based on the current oracle price and pool ETH and USM; or 0 if we're not currently underwater.
+     * @return usmSupplyForFumBuys The current supply of USM *for purposes of calculating the FUM buy price,* and therefore
+     * for `fumFromFund()`.  The "supply for FUM buys" is the *lesser* of the actual current USM supply, and the USM amount
+     * that would make debt ratio = `MAX_DEBT_RATIO`.  Example:
+     *
+     * 1. Suppose the system currently contains 50 ETH at price $1,000 (total pool value: $50,000), with an actual USM supply
+     *    of 30,000 USM.  Then debt ratio = 30,000 / $50,000 = 60%: < MAX 80%, so `usmSupplyForFumBuys` = 30,000.
+     * 2. Now suppose ETH/USD halves to $500.  Then pool value halves to $25,000, and debt ratio doubles to 120%.  Now
+     *    `usmSupplyForFumBuys` instead = 20,000: the USM quantity at which debt ratio would equal 80% (20,000 / $25,000).
+     *    (Call this the "80% supply".)
+     * 3. ...Except, we also gradually increase the supply over time while we remain underwater.  This has the effect of
+     *    *reducing* the FUM buy price inferred from that supply (higher JacobUSM supply -> smaller buffer -> lower FUM price).
+     *    The math we use gradually increases the supply from its initial "80% supply" value, where debt ratio =
+     *    `MAX_DEBT_RATIO` (20,000 above), to a theoretical maximum "100% supply" value, where debt ratio = 100% (in the $500
+     *    example above, this would be 25,000).  (Or the actual supply, whichever is lower: we never increase
+     *    `usmSupplyForFumBuys` above `usmActualSupply`.)  The climb from the initial 80% supply (20,000) to the 100% supply
+     *    (25,000) is at a rate that brings it "halfway closer per `MIN_FUM_BUY_PRICE_HALF_LIFE` (eg, 1 day)": so three days
+     *    after going underwater, the supply returned will be 25,000 - 0.5**3 * (25,000 - 20,000) = 24,375.
+     */
     function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater, uint currentTime)
         public override pure returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys, uint debtRatio_)
     {

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -78,23 +78,10 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
 
     // ____________________ External transactional functions ____________________
 
-    /**
-     * @notice Mint new USM, sending it to the given address, and only if the amount minted >= `minUsmOut`.  The amount of ETH
-     * is passed in as `msg.value`.
-     * @param to address to send the USM to.
-     * @param minUsmOut Minimum accepted USM for a successful mint.
-     */
     function mint(address to, uint minUsmOut) external payable override returns (uint usmOut) {
         usmOut = _mintUsm(to, minUsmOut);
     }
 
-    /**
-     * @dev Burn USM in exchange for ETH.
-     * @param from address to deduct the USM from.
-     * @param to address to send the ETH to.
-     * @param usmToBurn Amount of USM to burn.
-     * @param minEthOut Minimum accepted ETH for a successful burn.
-     */
     function burn(address from, address payable to, uint usmToBurn, uint minEthOut)
         external override
         onlyHolderOrDelegate(from, "Only holder or delegate")
@@ -103,23 +90,10 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         ethOut = _burnUsm(from, to, usmToBurn, minEthOut);
     }
 
-    /**
-     * @notice Funds the pool with ETH, minting new FUM and sending it to the given address, but only if the amount minted >=
-     * `minFumOut`.  The amount of ETH is passed in as `msg.value`.
-     * @param to address to send the FUM to.
-     * @param minFumOut Minimum accepted FUM for a successful fund.
-     */
     function fund(address to, uint minFumOut) external payable override returns (uint fumOut) {
         fumOut = _fundFum(to, minFumOut);
     }
 
-    /**
-     * @notice Defunds the pool by redeeming FUM in exchange for equivalent ETH from the pool.
-     * @param from address to deduct the FUM from.
-     * @param to address to send the ETH to.
-     * @param fumToBurn Amount of FUM to burn.
-     * @param minEthOut Minimum accepted ETH for a successful defund.
-     */
     function defund(address from, address payable to, uint fumToBurn, uint minEthOut)
         external override
         onlyHolderOrDelegateOrFUM(from, "Only holder or delegate or FUM")
@@ -386,10 +360,6 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         (price, updateTime) = oracle.latestPrice();
     }
 
-    /**
-     * @notice Total amount of ETH in the pool (ie, in the contract).
-     * @return pool ETH pool
-     */
     function ethPool() public override view returns (uint pool) {
         pool = address(this).balance;
     }
@@ -398,13 +368,6 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         supply = fum.totalSupply();
     }
 
-    /**
-     * @notice The current bid/ask adjustment, equal to the stored value decayed over time towards its stable value, 1.  This
-     * adjustment is intended as a measure of "how long-ETH recent user activity has been", so that we can slide price
-     * accordingly: if recent activity was mostly long-ETH (`fund()` and `burn()`), raise FUM buy price/reduce USM sell price;
-     * if recent activity was short-ETH (`defund()` and `mint()`), reduce FUM sell price/raise USM buy price.
-     * @return adjustment The sliding-price bid/ask adjustment
-     */
     function bidAskAdjustment() public override view returns (uint adjustment) {
         adjustment = loadState().bidAskAdjustment;      // Not just from storedState, b/c need to update it - see loadState()
     }
@@ -432,10 +395,6 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
 
     // ____________________ Public helper pure functions (for functions above) ____________________
 
-    /**
-     * @notice Calculate the amount of ETH in the buffer.
-     * @return buffer ETH buffer
-     */
     function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, WadMath.Round upOrDown)
         public override pure returns (int buffer)
     {
@@ -446,37 +405,19 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         buffer = int(ethInPool) - int(usmValueInEth);   // After the previous line, no over/underflow should be possible here
     }
 
-    /**
-     * @notice Calculate debt ratio for a given eth to USM price: ratio of the outstanding USM (amount of USM in total supply),
-     * to the current ETH pool value in USD (ETH qty * ETH/USD price).
-     * @return ratio Debt ratio (or 0 if there's currently 0 ETH in the pool/price = 0: these should never happen after launch)
-     */
     function debtRatio(uint ethUsdPrice, uint ethInPool, uint usmSupply) public override pure returns (uint ratio) {
         uint ethPoolValueInUsd = ethInPool.wadMulDown(ethUsdPrice);
         ratio = (ethPoolValueInUsd == 0 ? 0 : usmSupply.wadDivUp(ethPoolValueInUsd));
     }
 
-    /**
-     * @notice Convert ETH amount to USM using a ETH/USD price.
-     * @param ethAmount The amount of ETH to convert
-     * @return usmOut The amount of USM
-     */
     function ethToUsm(uint ethUsdPrice, uint ethAmount, WadMath.Round upOrDown) public override pure returns (uint usmOut) {
         usmOut = ethAmount.wadMul(ethUsdPrice, upOrDown);
     }
 
-    /**
-     * @notice Convert USM amount to ETH using a ETH/USD price.
-     * @param usmAmount The amount of USM to convert
-     * @return ethOut The amount of ETH
-     */
     function usmToEth(uint ethUsdPrice, uint usmAmount, WadMath.Round upOrDown) public override pure returns (uint ethOut) {
         ethOut = usmAmount.wadDiv(ethUsdPrice, upOrDown);
     }
 
-    /**
-     * @return price The ETH/USD price, adjusted by the `bidAskAdjustment` (if applicable) for the given buy/sell side.
-     */
     function adjustedEthUsdPrice(IUSM.Side side, uint ethUsdPrice, uint adjustment) public override pure returns (uint price) {
         price = ethUsdPrice;
 
@@ -487,21 +428,11 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         }
     }
 
-    /**
-     * @notice Calculate the *marginal* price of USM (in ETH terms): that is, of the next unit, before the price start sliding.
-     * @return price USM price in ETH terms
-     */
     function usmPrice(IUSM.Side side, uint ethUsdPrice) public override pure returns (uint price) {
         WadMath.Round upOrDown = (side == IUSM.Side.Buy ? WadMath.Round.Up : WadMath.Round.Down);
         price = usmToEth(ethUsdPrice, WAD, upOrDown);
     }
 
-    /**
-     * @notice Calculate the *marginal* price of FUM (in ETH terms): that is, of the next unit, before the price starts rising.
-     * @param usmEffectiveSupply should be either the actual current USM supply, or, when calculating the FUM *buy* price, the
-     * return value of `usmSupplyForFumBuys()`.
-     * @return price FUM price in ETH terms
-     */
     function fumPrice(IUSM.Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply)
         public override pure returns (uint price)
     {
@@ -516,27 +447,6 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
         }
     }
 
-    /**
-     * @return timeSystemWentUnderwater_ The time at which we first detected the system was underwater (debt ratio >
-     * `MAX_DEBT_RATIO`), based on the current oracle price and pool ETH and USM; or 0 if we're not currently underwater.
-     * @return usmSupplyForFumBuys The current supply of USM *for purposes of calculating the FUM buy price,* and therefore
-     * for `fumFromFund()`.  The "supply for FUM buys" is the *lesser* of the actual current USM supply, and the USM amount
-     * that would make debt ratio = `MAX_DEBT_RATIO`.  Example:
-     *
-     * 1. Suppose the system currently contains 50 ETH at price $1,000 (total pool value: $50,000), with an actual USM supply
-     *    of 30,000 USM.  Then debt ratio = 30,000 / $50,000 = 60%: < MAX 80%, so `usmSupplyForFumBuys` = 30,000.
-     * 2. Now suppose ETH/USD halves to $500.  Then pool value halves to $25,000, and debt ratio doubles to 120%.  Now
-     *    `usmSupplyForFumBuys` instead = 20,000: the USM quantity at which debt ratio would equal 80% (20,000 / $25,000).
-     *    (Call this the "80% supply".)
-     * 3. ...Except, we also gradually increase the supply over time while we remain underwater.  This has the effect of
-     *    *reducing* the FUM buy price inferred from that supply (higher JacobUSM supply -> smaller buffer -> lower FUM price).
-     *    The math we use gradually increases the supply from its initial "80% supply" value, where debt ratio =
-     *    `MAX_DEBT_RATIO` (20,000 above), to a theoretical maximum "100% supply" value, where debt ratio = 100% (in the $500
-     *    example above, this would be 25,000).  (Or the actual supply, whichever is lower: we never increase
-     *    `usmSupplyForFumBuys` above `usmActualSupply`.)  The climb from the initial 80% supply (20,000) to the 100% supply
-     *    (25,000) is at a rate that brings it "halfway closer per `MIN_FUM_BUY_PRICE_HALF_LIFE` (eg, 1 day)": so three days
-     *    after going underwater, the supply returned will be 25,000 - 0.5**3 * (25,000 - 20,000) = 24,375.
-     */
     function checkIfUnderwater(uint usmActualSupply, uint ethPool_, uint ethUsdPrice, uint oldTimeUnderwater, uint currentTime)
         public override pure returns (uint timeSystemWentUnderwater_, uint usmSupplyForFumBuys, uint debtRatio_)
     {


### PR DESCRIPTION
Seems like comments on the purpose of a function, rather than on a specific implementation, belong in the `IUSM` interface rather than the `USM` implementation?  (See ABDK issue #&#x2060;38.)