### PR TITLE
Replace (eg) wadMulDown(x, y) and wadMulUp(x, y) with wadMul(x, y, roundUp) - maybe?

### DIFF
--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "acc-erc20/contracts/IERC20.sol";
-import "./WadMath.sol";
 
 abstract contract IUSM is IERC20 {
     event UnderwaterStatusChanged(bool underwater);

--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -94,7 +94,7 @@ abstract contract IUSM is IERC20 {
      * @notice Calculate the amount of ETH in the buffer.
      * @return buffer ETH buffer
      */
-    function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, WadMath.Round upOrDown) public virtual pure returns (int buffer);
+    function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, bool roundUp) public virtual pure returns (int buffer);
 
     /**
      * @notice Calculate debt ratio for a given eth to USM price: ratio of the outstanding USM (amount of USM in total supply),
@@ -108,14 +108,14 @@ abstract contract IUSM is IERC20 {
      * @param ethAmount The amount of ETH to convert
      * @return usmOut The amount of USM
      */
-    function ethToUsm(uint ethUsdPrice, uint ethAmount, WadMath.Round upOrDown) public virtual pure returns (uint usmOut);
+    function ethToUsm(uint ethUsdPrice, uint ethAmount, bool roundUp) public virtual pure returns (uint usmOut);
 
     /**
      * @notice Convert USM amount to ETH using a ETH/USD price.
      * @param usmAmount The amount of USM to convert
      * @return ethOut The amount of ETH
      */
-    function usmToEth(uint ethUsdPrice, uint usmAmount, WadMath.Round upOrDown) public virtual pure returns (uint ethOut);
+    function usmToEth(uint ethUsdPrice, uint usmAmount, bool roundUp) public virtual pure returns (uint ethOut);
 
     /**
      * @return price The ETH/USD price, adjusted by the `bidAskAdjustment` (if applicable) for the given buy/sell side.

--- a/contracts/USM.sol
+++ b/contracts/USM.sol
@@ -440,12 +440,11 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
      * @notice Calculate the amount of ETH in the buffer.
      * @return buffer ETH buffer
      */
-    function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, WadMath.Round upOrDown)
+    function ethBuffer(uint ethUsdPrice, uint ethInPool, uint usmSupply, bool roundUp)
         public override pure returns (int buffer)
     {
         // Reverse the input upOrDown, since we're using it for usmToEth(), which will be *subtracted* from ethInPool below:
-        WadMath.Round downOrUp = (upOrDown == WadMath.Round.Down ? WadMath.Round.Up : WadMath.Round.Down);
-        uint usmValueInEth = usmToEth(ethUsdPrice, usmSupply, downOrUp);
+        uint usmValueInEth = usmToEth(ethUsdPrice, usmSupply, !roundUp);    // Iff rounding the buffer up, round usmValue down
         require(ethUsdPrice <= uint(type(int).max) && usmValueInEth <= uint(type(int).max), "ethBuffer overflow/underflow");
         buffer = int(ethInPool) - int(usmValueInEth);   // After the previous line, no over/underflow should be possible here
     }
@@ -465,8 +464,8 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
      * @param ethAmount The amount of ETH to convert
      * @return usmOut The amount of USM
      */
-    function ethToUsm(uint ethUsdPrice, uint ethAmount, WadMath.Round upOrDown) public override pure returns (uint usmOut) {
-        usmOut = ethAmount.wadMul(ethUsdPrice, upOrDown);
+    function ethToUsm(uint ethUsdPrice, uint ethAmount, bool roundUp) public override pure returns (uint usmOut) {
+        usmOut = ethAmount.wadMul(ethUsdPrice, roundUp);
     }
 
     /**
@@ -474,8 +473,8 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
      * @param usmAmount The amount of USM to convert
      * @return ethOut The amount of ETH
      */
-    function usmToEth(uint ethUsdPrice, uint usmAmount, WadMath.Round upOrDown) public override pure returns (uint ethOut) {
-        ethOut = usmAmount.wadDiv(ethUsdPrice, upOrDown);
+    function usmToEth(uint ethUsdPrice, uint usmAmount, bool roundUp) public override pure returns (uint ethOut) {
+        ethOut = usmAmount.wadDiv(ethUsdPrice, roundUp);
     }
 
     /**
@@ -486,8 +485,7 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
 
         // Apply the adjustment if (side == Buy and adj > 1), or (side == Sell and adj < 1):
         if (side == IUSM.Side.Buy ? (adjustment > WAD) : (adjustment < WAD)) {
-            WadMath.Round upOrDown = (side == IUSM.Side.Buy ? WadMath.Round.Up : WadMath.Round.Down);
-            price = price.wadMul(adjustment, upOrDown);
+            price = price.wadMul(adjustment, side == IUSM.Side.Buy);    // Round up iff side = buy
         }
     }
 
@@ -496,8 +494,7 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
      * @return price USM price in ETH terms
      */
     function usmPrice(IUSM.Side side, uint ethUsdPrice) public override pure returns (uint price) {
-        WadMath.Round upOrDown = (side == IUSM.Side.Buy ? WadMath.Round.Up : WadMath.Round.Down);
-        price = usmToEth(ethUsdPrice, WAD, upOrDown);
+        price = usmToEth(ethUsdPrice, WAD, side == IUSM.Side.Buy);      // Round up iff side = buy
     }
 
     /**
@@ -509,14 +506,14 @@ contract USM is IUSM, Oracle, ERC20Permit, WithOptOut, Delegable {
     function fumPrice(IUSM.Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply)
         public override pure returns (uint price)
     {
-        WadMath.Round upOrDown = (side == IUSM.Side.Buy ? WadMath.Round.Up : WadMath.Round.Down);
+        bool roundUp = (side == IUSM.Side.Buy);
         if (fumSupply == 0) {
-            price = usmToEth(ethUsdPrice, WAD, upOrDown);   // if no FUM issued yet, default fumPrice to 1 USD (in ETH terms)
+            price = usmToEth(ethUsdPrice, WAD, roundUp);    // if no FUM issued yet, default fumPrice to 1 USD (in ETH terms)
         } else {
             // Using usmEffectiveSupply here, rather than just the raw actual supply, has the effect of bumping the FUM price
             // up to the minFumBuyPrice when needed (ie, when debt ratio > MAX_DEBT_RATIO):
-            int buffer = ethBuffer(ethUsdPrice, ethInPool, usmEffectiveSupply, upOrDown);
-            price = (buffer <= 0 ? 0 : uint(buffer).wadDiv(fumSupply, upOrDown));
+            int buffer = ethBuffer(ethUsdPrice, ethInPool, usmEffectiveSupply, roundUp);
+            price = (buffer <= 0 ? 0 : uint(buffer).wadDiv(fumSupply, roundUp));
         }
     }
 

--- a/contracts/USMView.sol
+++ b/contracts/USMView.sol
@@ -21,9 +21,9 @@ contract USMView {
      * @notice Calculate the amount of ETH in the buffer.
      * @return buffer ETH buffer
      */
-    function ethBuffer(WadMath.Round upOrDown) external view returns (int buffer) {
+    function ethBuffer(bool roundUp) external view returns (int buffer) {
         (uint price, ) = usm.latestPrice();
-        buffer = usm.ethBuffer(price, usm.ethPool(), usm.totalSupply(), upOrDown);
+        buffer = usm.ethBuffer(price, usm.ethPool(), usm.totalSupply(), roundUp);
     }
 
     /**
@@ -31,9 +31,9 @@ contract USMView {
      * @param ethAmount The amount of ETH to convert
      * @return usmOut The amount of USM
      */
-    function ethToUsm(uint ethAmount, WadMath.Round upOrDown) external view returns (uint usmOut) {
+    function ethToUsm(uint ethAmount, bool roundUp) external view returns (uint usmOut) {
         (uint price, ) = usm.latestPrice();
-        usmOut = usm.ethToUsm(price, ethAmount, upOrDown);
+        usmOut = usm.ethToUsm(price, ethAmount, roundUp);
     }
 
     /**
@@ -41,9 +41,9 @@ contract USMView {
      * @param usmAmount The amount of USM to convert
      * @return ethOut The amount of ETH
      */
-    function usmToEth(uint usmAmount, WadMath.Round upOrDown) external view returns (uint ethOut) {
+    function usmToEth(uint usmAmount, bool roundUp) external view returns (uint ethOut) {
         (uint price, ) = usm.latestPrice();
-        ethOut = usm.usmToEth(price, usmAmount, upOrDown);
+        ethOut = usm.usmToEth(price, usmAmount, roundUp);
     }
 
     /**

--- a/contracts/WadMath.sol
+++ b/contracts/WadMath.sol
@@ -7,8 +7,6 @@ pragma solidity ^0.8.0;
  * @author Alberto Cuesta Cañada, Jacob Eliosoff, Alex Roan
  */
 library WadMath {
-    enum Round {Down, Up}
-
     uint public constant WAD = 1e18;
     uint public constant WAD_MINUS_1 = WAD - 1;
     uint public constant HALF_WAD = WAD / 2;
@@ -20,8 +18,8 @@ library WadMath {
     uint public constant FLOOR_LOG_2_E_SCALED_OVER_WAD = 3835341275459348169;               // log2(e) * 2**121 / 1e18
     uint public constant  CEIL_LOG_2_E_SCALED_OVER_WAD = 3835341275459348170;               // log2(e) * 2**121 / 1e18
 
-    function wadMul(uint x, uint y, Round upOrDown) internal pure returns (uint z) {
-        z = (upOrDown == Round.Down ? wadMulDown(x, y) : wadMulUp(x, y));
+    function wadMul(uint x, uint y, bool roundUp) internal pure returns (uint z) {
+        z = (roundUp ? wadMulUp(x, y) : wadMulDown(x, y));
     }
 
     function wadMulDown(uint x, uint y) internal pure returns (uint z) {
@@ -44,8 +42,8 @@ library WadMath {
         unchecked { z /= WAD; }
     }
 
-    function wadDiv(uint x, uint y, Round upOrDown) internal pure returns (uint z) {
-        z = (upOrDown == Round.Down ? wadDivDown(x, y) : wadDivUp(x, y));
+    function wadDiv(uint x, uint y, bool roundUp) internal pure returns (uint z) {
+        z = (roundUp ? wadDivUp(x, y) : wadDivDown(x, y));
     }
 
     function wadDivDown(uint x, uint y) internal pure returns (uint z) {

--- a/test/02_USM_internal.test.js
+++ b/test/02_USM_internal.test.js
@@ -11,7 +11,6 @@ require('chai').use(require('chai-as-promised')).should()
 contract('USM - Internal functions', (accounts) => {
   const [deployer, user1, user2, user3] = accounts
   let usm, usmView
-  const rounds = { DOWN: 0, UP: 1 }
 
   const ZERO = new BN('0')
   const WAD = new BN('1000000000000000000')
@@ -34,14 +33,14 @@ contract('USM - Internal functions', (accounts) => {
     it('returns the value of eth in usm', async () => {
       const oneEth = WAD
       const equivalentUSM = oneEth.mul(priceWAD).div(WAD)
-      const usmAmount = await usmView.ethToUsm(oneEth, rounds.DOWN)
+      const usmAmount = await usmView.ethToUsm(oneEth, false)
       usmAmount.toString().should.equal(equivalentUSM.toString())
     })
 
     it('returns the value of usm in eth', async () => {
       const oneUsm = WAD
       const equivalentEth = oneUsm.mul(WAD).div(priceWAD)
-      const ethAmount = await usmView.usmToEth(oneUsm, rounds.DOWN)
+      const ethAmount = await usmView.usmToEth(oneUsm, false)
       ethAmount.toString().should.equal(equivalentEth.toString())
     })
 


### PR DESCRIPTION
The idea, from ABDK, is to simplify away `wadMulDown()`, `wadMulUp()`, `wadDivDown()`, `wadDivUp()`, and just rely on `wadMul()` and `wadDiv()` delegating to new fn `divRounded()`.  But this seems to add nontrivial gas, eg 1,600 to `defund()`: I think this is either because it results in divisions by WAD being (unnecessarily) checked, or because of overhead from passing the extra `roundUp` arg around.  On balance I'm inclined to scrap this change and leave `wadMulDown()` etc as they are.