### PR TITLE
Added an initial "prefund period"

### DIFF
--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -87,6 +87,8 @@ abstract contract IUSM is IERC20 {
 
     function timeSystemWentUnderwater() public virtual view returns (uint timestamp);
 
+    function isDuringPrefund() public virtual view returns (bool duringPrefund);
+
     // ____________________ Public helper pure functions (for functions above) ____________________
 
     /**
@@ -133,7 +135,7 @@ abstract contract IUSM is IERC20 {
      * return value of `usmSupplyForFumBuys()`.
      * @return price FUM price in ETH terms
      */
-    function fumPrice(Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply) public virtual pure returns (uint price);
+    function fumPrice(Side side, uint ethUsdPrice, uint ethInPool, uint usmEffectiveSupply, uint fumSupply, bool prefund) public virtual pure returns (uint price);
 
     /**
      * @return timeSystemWentUnderwater_ The time at which we first detected the system was underwater (debt ratio >

--- a/contracts/USMView.sol
+++ b/contracts/USMView.sol
@@ -67,10 +67,20 @@ contract USMView {
     }
 
     /**
-     * @notice Calculate the *marginal* price of FUM (in ETH terms) - that is, of the next unit, before price start sliding.
+     * @notice Calculate the marginal price of FUM, based on whether we're currently in the prefund period or not.
      * @return price FUM price in ETH terms
      */
     function fumPrice(IUSM.Side side) external view returns (uint price) {
+        price = fumPrice(side, usm.isDuringPrefund());
+    }
+
+    // ____________________ Public informational view functions ____________________
+
+    /**
+     * @notice Calculate the *marginal* price of FUM (in ETH terms) - that is, of the next unit, before price start sliding.
+     * @return price FUM price in ETH terms
+     */
+    function fumPrice(IUSM.Side side, bool prefund) public view returns (uint price) {
         (uint ethUsdPrice, ) = usm.latestPrice();
         uint adjustedPrice = usm.adjustedEthUsdPrice(side, ethUsdPrice, usm.bidAskAdjustment());
         uint ethPool = usm.ethPool();
@@ -79,6 +89,6 @@ contract USMView {
         if (side == IUSM.Side.Buy) {
             (, usmSupply, ) = usm.checkIfUnderwater(usmSupply, ethPool, ethUsdPrice, oldTimeUnderwater, block.timestamp);
         }
-        price = usm.fumPrice(side, adjustedPrice, ethPool, usmSupply, usm.fumTotalSupply());
+        price = usm.fumPrice(side, adjustedPrice, ethPool, usmSupply, usm.fumTotalSupply(), prefund);
     }
 }


### PR DESCRIPTION
The prefund period is the period before a specified date (eg, Nov 1 2021) during which the FUM/ETH exchange rate is fixed, rather than fluctuating (potentially wildly) from the moment of the first fund() call.