### PR TITLE
Removed Oracle.refreshPrice()

### DIFF
--- a/contracts/IUSM.sol
+++ b/contracts/IUSM.sol
@@ -46,10 +46,6 @@ abstract contract IUSM is IERC20 {
      */
     function defund(address from, address payable to, uint fumToBurn, uint minEthOut) external virtual returns (uint ethOut);
 
-    // ____________________ Public transactional functions ____________________
-
-    function refreshPrice() public virtual returns (uint price, uint updateTime);
-
     // ____________________ Public Oracle view functions ____________________
 
     /**

--- a/contracts/mocks/GasMeasuredOracleWrapper.sol
+++ b/contracts/mocks/GasMeasuredOracleWrapper.sol
@@ -20,11 +20,4 @@ contract GasMeasuredOracleWrapper is Oracle {
         uint gasEnd = gasleft();
         console.log("        ", oracleName, "oracle.latestPrice() cost: ", gasStart - gasEnd);
     }
-
-    function refreshPrice() public virtual override returns (uint price, uint updateTime) {
-        uint gasStart = gasleft();
-        (price, updateTime) = measuredOracle.refreshPrice();
-        uint gasEnd = gasleft();
-        console.log("        ", oracleName, "oracle.refreshPrice() cost: ", gasStart - gasEnd);
-    }
 }

--- a/contracts/mocks/MockChainlinkOracle.sol
+++ b/contracts/mocks/MockChainlinkOracle.sol
@@ -12,10 +12,6 @@ import "../oracles/ChainlinkOracle.sol";
 contract MockChainlinkOracle is ChainlinkOracle, SettableOracle {
     constructor(AggregatorV3Interface aggregator_) ChainlinkOracle(aggregator_) {}
 
-    function refreshPrice() public override returns (uint price, uint updateTime) {
-        (price, updateTime) = (savedPrice != 0) ? (savedPrice, savedUpdateTime) : super.refreshPrice();
-    }
-
     function latestPrice() public override(ChainlinkOracle, Oracle) view returns (uint price, uint updateTime) {
         (price, updateTime) = (savedPrice != 0) ? (savedPrice, savedUpdateTime) : super.latestPrice();
     }

--- a/contracts/mocks/MockMedianOracle.sol
+++ b/contracts/mocks/MockMedianOracle.sol
@@ -19,10 +19,6 @@ contract MockMedianOracle is MedianOracle, SettableOracle {
             uniswapPool1, uniswapTokenToPrice1, uniswapDecimals1,
             uniswapPool2, uniswapTokenToPrice2, uniswapDecimals2) {}
 
-    function refreshPrice() public override(MedianOracle, Oracle) returns (uint price, uint updateTime) {
-        (price, updateTime) = (savedPrice != 0) ? (savedPrice, savedUpdateTime) : super.refreshPrice();
-    }
-
     function latestPrice() public override(MedianOracle, Oracle) view returns (uint price, uint updateTime) {
         (price, updateTime) = (savedPrice != 0) ? (savedPrice, savedUpdateTime) : super.latestPrice();
     }

--- a/contracts/oracles/MedianOracle.sol
+++ b/contracts/oracles/MedianOracle.sol
@@ -45,12 +45,6 @@ contract MedianOracle is ChainlinkOracle, UniswapV3TWAPOracle, UniswapV3TWAPOrac
         (price, updateTime) = UniswapV3TWAPOracle2.latestPrice();
     }
 
-    function refreshPrice() public virtual override(Oracle)
-        returns (uint price, uint updateTime)
-    {
-        (price, updateTime) = latestPrice();
-    }
-
     /**
      * @notice Currently only supports three inputs
      * @return price the median price of the three passed in

--- a/contracts/oracles/Oracle.sol
+++ b/contracts/oracles/Oracle.sol
@@ -3,25 +3,14 @@ pragma solidity ^0.8.0;
 
 abstract contract Oracle {
     /**
-     * @notice Doesn't refresh the price, but returns the latest value available without doing any transactional operations:
-     * eg, the price cached by the most recent call to `refreshPrice()`.
      * @return price WAD-scaled - 18 dec places
      * @return updateTime The last time the price was updated.  This is a bit subtle: `price` can change without `updateTime`
      * changing.  Suppose, eg, the current Uniswap v3 TWAP price over the last 10 minutes is $3,000, and then Uniswap records a
-     * new trade observation at a price of $3,020.  This will increase the 10-minute TWAP slightly above $3,000, and reset
-     * `updateTime` to the new trade's time.  But, over the subsequent 10 minutes the 10-minute TWAP will continue to increase,
-     * as more and more of "the last 10 minutes" is at $3,020 rather than $3,000: but because this gradual price change is only
-     * driven by the passage of time, not by any new price observations, it will *not* change `updateTime`, which will remain
-     * at the time of the $3,020 trade until another trade occurs.
+     * new trade observation at a price of $2,980.  This will nudge the 10-minute TWAP slightly below $3,000, and reset
+     * `updateTime` to the new trade's time.  However, over the subsequent 10 minutes, the 10-minute TWAP will continue to
+     * decrease, as more and more of "the last 10 minutes" is at $2,980 rather than $3,000: but because this gradual price
+     * change is only driven by the passage of time, not by any new price observations, it will *not* change `updateTime`,
+     * which will remain at the time of the $2,980 trade until another trade occurs.
      */
     function latestPrice() public virtual view returns (uint price, uint updateTime);
-
-    /**
-     * @notice Does whatever work or queries will yield the most up-to-date price, and returns it (typically also caching it
-     * for `latestPrice()` callers).
-     * @return price WAD-scaled - 18 dec places
-     */
-    function refreshPrice() public virtual returns (uint price, uint updateTime) {
-        (price, updateTime) = latestPrice();    // Default implementation doesn't do any caching.  But override as needed
-    }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@chainlink/contracts": "0.0.9",
-    "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@uniswap/v3-periphery": "^1.2.0"
   }
 }

--- a/test/01_TestOracle.test.js
+++ b/test/01_TestOracle.test.js
@@ -114,7 +114,6 @@ contract('Oracle pricing', (accounts) => {
 
       oracle = await UniswapV3TWAPOracle.new(pool.address, ethUsdtTokenToPrice, ethUsdtDecimals, { from: deployer })
       oracle = await GasMeasuredOracleWrapper.new(oracle.address, "uniswapV3TWAP", { from: deployer })
-      await oracle.refreshPrice()
     })
 
     it('returns the correct price', async () => {
@@ -158,7 +157,6 @@ contract('Oracle pricing', (accounts) => {
         usdcEthPool.address, usdcEthTokenToPrice, usdcEthDecimals,
         ethUsdtPool.address, ethUsdtTokenToPrice, ethUsdtDecimals, { from: deployer })
       oracle = await GasMeasuredOracleWrapper.new(rawOracle.address, "median", { from: deployer })
-      await oracle.refreshPrice()
     })
 
     it('returns the correct price', async () => {
@@ -166,7 +164,6 @@ contract('Oracle pricing', (accounts) => {
       const uniswapPrice1 = (await rawOracle.latestUniswapV3TWAPPrice1())[0]
       const uniswapPrice2 = (await rawOracle.latestUniswapV3TWAPPrice2())[0]
       const targetOraclePrice = median(chainlinkPriceWAD, uniswapPrice1, uniswapPrice2)
-      //console.log("Prices: oracle " + fl(oraclePrice) + ", target " + fl(targetOraclePrice) + ", Chainlink " + fl((await rawOracle.latestChainlinkPrice())[0]) + ", Uniswap1 " + fl(uniswapPrice1) + ", Uniswap2 " + fl(uniswapPrice2))
       oraclePrice.toString().should.equal(targetOraclePrice.toString())
     })
 

--- a/test/02_USM_internal.test.js
+++ b/test/02_USM_internal.test.js
@@ -20,7 +20,6 @@ contract('USM - Internal functions', (accounts) => {
   beforeEach(async () => {
     oracle = await TestOracle.new(priceWAD, { from: deployer })
     usm = await USM.new(oracle.address, [], { from: deployer })
-    await usm.refreshPrice()    // Ensures the savedPrice set in TestOracle is also set in usm.storedPrice
     usmView = await USMView.new(usm.address, { from: deployer })
   })
 

--- a/test/03_USM.test.js
+++ b/test/03_USM.test.js
@@ -177,7 +177,6 @@ contract('USM', (accounts) => {
         usdcEthPool.address, usdcEthTokenToPrice, usdcEthDecimals,
         ethUsdtPool.address, ethUsdtTokenToPrice, ethUsdtDecimals, { from: deployer })
       usm = await USM.new(oracle.address, [optOut1, optOut2], { from: deployer })
-      await usm.refreshPrice()
       fum = await FUM.at(await usm.fum())
       usmView = await USMView.new(usm.address, { from: deployer })
 
@@ -455,7 +454,6 @@ contract('USM', (accounts) => {
             const priceChangeFactor1 = wadDiv(debtRatio0, targetDebtRatio1, true)
             const targetPrice1 = wadMul(price0, priceChangeFactor1, false)
             await oracle.setPrice(targetPrice1)
-            await usm.refreshPrice()    // Need to refreshPrice() after setPrice(), to get the new value into usm.storedPrice
             const price1 = (await usm.latestPrice())[0]
             shouldEqualApprox(price1, targetPrice1)
 
@@ -609,7 +607,6 @@ contract('USM', (accounts) => {
             const priceChangeFactor = wadDiv(debtRatio0, targetDebtRatio, true)
             const targetPrice = wadMul(price0, priceChangeFactor, false)
             await oracle.setPrice(targetPrice)
-            await usm.refreshPrice()
             const price = (await usm.latestPrice())[0]
             shouldEqualApprox(price, targetPrice)
 
@@ -794,7 +791,6 @@ contract('USM', (accounts) => {
             const priceChangeFactor1 = wadDiv(debtRatio0, targetDebtRatio1, false)
             const targetPrice1 = wadMul(price0, priceChangeFactor1, true)
             await oracle.setPrice(targetPrice1)
-            await usm.refreshPrice()
             const price1 = (await usm.latestPrice())[0]
             shouldEqualApprox(price1, targetPrice1)
 
@@ -810,7 +806,6 @@ contract('USM', (accounts) => {
             const priceChangeFactor3 = wadDiv(debtRatio2, targetDebtRatio3, true)
             const targetPrice3 = wadMul(price1, priceChangeFactor3, false)
             await oracle.setPrice(targetPrice3)
-            await usm.refreshPrice()
             const price3 = (await usm.latestPrice())[0]
             shouldEqualApprox(price3, targetPrice3)
 
@@ -964,7 +959,6 @@ contract('USM', (accounts) => {
             const priceChangeFactor1 = wadDiv(debtRatio0, targetDebtRatio1, false)
             const targetPrice1 = wadMul(price0, priceChangeFactor1, true)
             await oracle.setPrice(targetPrice1)
-            await usm.refreshPrice()
             const price1 = (await usm.latestPrice())[0]
             shouldEqualApprox(price1, targetPrice1)
 
@@ -989,7 +983,6 @@ contract('USM', (accounts) => {
             const priceChangeFactor3 = wadDiv(debtRatio2, targetDebtRatio3, true)
             const targetPrice3 = wadMul(price1, priceChangeFactor3, false)
             await oracle.setPrice(targetPrice3)
-            await usm.refreshPrice()
             const price3 = (await usm.latestPrice())[0]
             shouldEqualApprox(price3, targetPrice3)
 

--- a/test/04_Proxy_Eth.test.js
+++ b/test/04_Proxy_Eth.test.js
@@ -33,7 +33,6 @@ contract('USM - USMWETHProxy - Eth', (accounts) => {
       weth = await WETH9.new({ from: deployer })
       oracle = await TestOracle.new(priceWAD, { from: deployer })
       usm = await USM.new(oracle.address, [], { from: deployer })
-      await usm.refreshPrice()  // Ensures the savedPrice passed to the constructor above is also set in usm.storedPrice
       fum = await FUM.at(await usm.fum())
       usmView = await USMView.new(usm.address, { from: deployer })
       proxy = await USMWETHProxy.new(usm.address, weth.address, { from: deployer })


### PR DESCRIPTION
No longer needed now that we've scrapped Uniswap V2 and `CompoundOpenOracle`.  Much nicer!